### PR TITLE
Don't use type variables in patterns

### DIFF
--- a/horde-ad.cabal
+++ b/horde-ad.cabal
@@ -132,7 +132,7 @@ library
     -- Other library packages from which modules are imported.
     build-depends:
         assert-failure
-      , base >= 4.16 && < 99
+      , base >= 4.14 && < 99
       , bytestring
       , ghc-typelits-knownnat
       , ghc-typelits-natnormalise

--- a/src/HordeAd/Core/Delta.hs
+++ b/src/HordeAd/Core/Delta.hs
@@ -49,6 +49,7 @@ import qualified Data.Array.Internal.DynamicS
 import qualified Data.Array.ShapedS as OS
 import           Data.Kind (Type)
 import           Data.List (foldl')
+import           Data.Proxy (Proxy(Proxy))
 import qualified Data.Strict.Vector as Data.Vector
 import qualified Data.Strict.Vector.Autogen.Mutable as Data.Vector.Mutable
 import qualified Data.Vector.Generic as V
@@ -182,13 +183,13 @@ data DeltaS :: [Nat] -> Type -> Type where
     -- ^ Append two arrays along the outermost dimension.
   SliceS :: forall i n k rest r.
             (KnownNat i, KnownNat n, KnownNat k, OS.Shape rest)
-         => DeltaS (i + n + k ': rest) r -> DeltaS (n ': rest) r
+         => Proxy i -> Proxy n -> DeltaS (i + n + k ': rest) r -> DeltaS (n ': rest) r
     -- ^ Extract a slice of an array along the outermost dimension.
 
   From0S :: Delta0 r -> DeltaS '[] r
   From1S :: Delta1 r -> DeltaS '[n] r
   From2S :: forall rows cols r. KnownNat cols
-         => Delta2 r -> DeltaS '[rows, cols] r
+         => Proxy cols -> Delta2 r -> DeltaS '[rows, cols] r
   FromXS :: DeltaX r -> DeltaS sh r
 
 instance Show (DeltaS sh r) where
@@ -459,12 +460,11 @@ buildVectors st deltaTopLevel = do
         VarS (DeltaId i) -> VM.modify storeX (addToArrayS r) i
 
         AppendS d e -> appendS r d e
-        SliceS @i d -> sliceS @i r d
-          -- is it possible to do that without type patterns and so GHC >= 9.2?
+        SliceS (_ :: Proxy i) _ d -> sliceS @i r d
 
         From0S d -> eval0 (OS.unScalar r) d
         From1S d -> eval1 (OS.toVector r) d
-        From2S @_ @cols d ->
+        From2S (_ :: Proxy cols) d ->
           eval2 (MO.MatrixOuter
                    (Just $ HM.reshape (valueOf @cols) $ OS.toVector r)
                    Nothing Nothing)
@@ -609,11 +609,11 @@ evalBindingsForward st deltaTopLevel (params0, paramsV0, paramsL0, paramsX0) =
         VarS (DeltaId i) -> Data.Array.Convert.convert $ paramsX V.! i
 
         AppendS d e -> evalS parameters d `OS.append` evalS parameters e
-        SliceS @i @n d -> OS.slice @'[ '(i, n) ] $ evalS parameters d
+        SliceS (_ :: Proxy i) (_ :: Proxy n) d -> OS.slice @'[ '(i, n) ] $ evalS parameters d
 
         From0S d -> OS.scalar $ eval0 parameters d
         From1S d -> OS.fromVector $ eval1 parameters d
-        From2S d -> OS.fromVector $ HM.flatten $ eval2 parameters d
+        From2S _ d -> OS.fromVector $ HM.flatten $ eval2 parameters d
         FromXS d -> Data.Array.Convert.convert $ evalX parameters d
       evalUnlessZero :: Domains r -> DeltaBinding r -> Domains r
       evalUnlessZero parameters@(!params, !paramsV, !paramsL, !paramsX) = \case

--- a/src/HordeAd/Core/DualNumber.hs
+++ b/src/HordeAd/Core/DualNumber.hs
@@ -14,6 +14,7 @@ import qualified Data.Array.DynamicS as OT
 import           Data.Array.Internal (valueOf)
 import qualified Data.Array.ShapedS as OS
 import           Data.List.Index (imap)
+import           Data.Proxy (Proxy(Proxy))
 import qualified Data.Strict.Vector as Data.Vector
 import qualified Data.Vector.Generic as V
 import           GHC.TypeLits (KnownNat, type (+))
@@ -339,7 +340,7 @@ sliceS :: forall i n k rest r.
           (KnownNat i, KnownNat n, KnownNat k, OS.Shape rest)
        => DualNumber (OS.Array (i + n + k ': rest) r)
        -> DualNumber (OS.Array (n ': rest) r)
-sliceS (D u u') = D (OS.slice @'[ '(i, n) ] u) (SliceS @i u')
+sliceS (D u u') = D (OS.slice @'[ '(i, n) ] u) (SliceS @i Proxy Proxy u')
 
 from0S :: IsScalar r => DualNumber r -> DualNumber (OS.Array '[] r)
 from0S (D u u') = D (OS.scalar u) (From0S u')


### PR DESCRIPTION
This PR is an attempt to fix part #13 (getting GHC 8.10.7 compatibility). But it doesn't work, because of an overlapping instance. The sad thing is that I think there really is an overlapping instance. I will report a GHC bug about this shortly.