### PR TITLE
Eliminate the explosion of spurious IsScalarS constraints

### DIFF
--- a/horde-ad.cabal
+++ b/horde-ad.cabal
@@ -185,6 +185,7 @@ test-suite test
         base
       , deepseq
       , ghc-typelits-knownnat
+      , ghc-typelits-natnormalise
       , hmatrix
       , horde-ad
       , orthotope
@@ -229,6 +230,7 @@ test-suite shortTestForCI
         base
       , deepseq
       , ghc-typelits-knownnat
+      , ghc-typelits-natnormalise
       , hmatrix
       , horde-ad
       , orthotope

--- a/src/HordeAd/Core/DualClass.hs
+++ b/src/HordeAd/Core/DualClass.hs
@@ -12,7 +12,6 @@
 module HordeAd.Core.DualClass
   ( IsDualWithScalar, IsScalar
   , IsScalarS  -- TODO: remove with GHC 9.4
-  , IsScalarS5, IsScalarS4, IsScalarS3, IsScalarS2, IsScalarS1
   , HasDelta, HasForward
   , IsDual(Primal, dZero, dScale, dAdd, dVar, bindInState)
   , HasRanks(..), TensorS
@@ -67,36 +66,6 @@ type IsScalar r =
 
 type IsScalarS r =
        (IsScalar r, IsDualS (TensorS r), ScalarOfS (TensorS r) ~ Primal r)
-
--- Five ranks ought to be enough for anyone.
-type IsScalarS5 r k5 k4 k3 k2 k1 =
-       ( KnownNat k5
-       , OS.Shape '[k5, k4, k3, k2, k1]
-       , IsScalarS r
-       , IsScalarS4 r k4 k3 k2 k1 )
-
-type IsScalarS4 r k4 k3 k2 k1 =
-       ( KnownNat k4
-       , OS.Shape '[k4, k3, k2, k1]
-       , IsScalarS r
-       , IsScalarS3 r k3 k2 k1 )
-
-type IsScalarS3 r k3 k2 k1 =
-       ( KnownNat k3
-       , OS.Shape '[k3, k2, k1]
-       , IsScalarS r
-       , IsScalarS2 r k2 k1 )
-
-type IsScalarS2 r k2 k1 =
-       ( KnownNat k2
-       , OS.Shape '[k2, k1]
-       , IsScalarS r
-       , IsScalarS1 r k1 )
-
-type IsScalarS1 r k1 =
-       ( KnownNat k1
-       , OS.Shape '[k1]
-       , IsScalarS r )
 
 -- | A constraint expressing that dual numbers with this dual component
 -- are implemented via gathering delta expressions in state.

--- a/src/HordeAd/Core/DualClass.hs
+++ b/src/HordeAd/Core/DualClass.hs
@@ -57,8 +57,8 @@ type IsScalar r =
 -- separate, because it requires an additional type argument representing
 -- the shape.
 type IsScalarS sh r =
-       ( OS.Shape sh, IsScalar r, IsDualWithScalar (TensorS sh r) r
-       , Primal (TensorS sh r) ~ OS.Array sh (Primal r) )
+       ( OS.Shape sh, IsScalar r, IsDualWithScalar (TensorS r sh) r
+       , Primal (TensorS r sh) ~ OS.Array sh (Primal r) )
 
 -- Five ranks ought to be enough for anyone.
 type IsScalarS5 r k5 k4 k3 k2 k1 =
@@ -142,13 +142,13 @@ class HasRanks r where
   type Tensor1 r = result | result -> r
   type Tensor2 r = result | result -> r
   type TensorX r = result | result -> r
-  type TensorS (sh :: [Nat]) r = result | result -> sh r
+  type TensorS r (sh :: [Nat]) = result | result -> sh r
 
   dSumElements0 :: Tensor1 r -> Int -> r
   dIndex0 :: Tensor1 r -> Int -> Int -> r
   dDot0 :: Primal (Tensor1 r) -> Tensor1 r -> r
   dFromX0 :: TensorX r -> r
-  dFromS0 :: TensorS '[] r -> r
+  dFromS0 :: TensorS r '[] -> r
 
   dSeq1 :: Data.Vector.Vector r -> Tensor1 r
   dKonst1 :: r -> Int -> Tensor1 r
@@ -160,12 +160,12 @@ class HasRanks r where
   dMD_V1 :: Tensor2 r -> Primal (Tensor1 r) -> Tensor1 r
   dFromX1 :: TensorX r -> Tensor1 r
   dFromS1 :: KnownNat len
-          => TensorS '[len] r -> Tensor1 r
+          => TensorS r '[len] -> Tensor1 r
   dReverse1 :: Tensor1 r -> Tensor1 r
   dFlatten1 :: Int -> Int -> Tensor2 r -> Tensor1 r
   dFlattenX1 :: OT.ShapeL -> TensorX r -> Tensor1 r
   dFlattenS1 :: OS.Shape sh
-             => TensorS sh r -> Tensor1 r
+             => TensorS r sh -> Tensor1 r
 
   dFromRows2 :: Data.Vector.Vector (Tensor1 r) -> Tensor2 r
   dFromColumns2 :: Data.Vector.Vector (Tensor1 r) -> Tensor2 r
@@ -181,7 +181,7 @@ class HasRanks r where
   dAsColumn2 :: Tensor1 r -> Tensor2 r
   dFromX2 :: TensorX r -> Tensor2 r
   dFromS2 :: (KnownNat rows, KnownNat cols)
-          => TensorS '[rows, cols] r -> Tensor2 r
+          => TensorS r '[rows, cols] -> Tensor2 r
 
   dFlipud2 :: Tensor2 r -> Tensor2 r
   dFliprl2 :: Tensor2 r -> Tensor2 r
@@ -198,27 +198,27 @@ class HasRanks r where
   dFrom1X :: Tensor1 r -> TensorX r
   dFrom2X :: Tensor2 r -> Int -> TensorX r
   dFromSX :: OS.Shape sh
-          => TensorS sh r -> TensorX r
+          => TensorS r sh -> TensorX r
 
   dKonstS :: OS.Shape sh
-          => r -> TensorS sh r
+          => r -> TensorS r sh
   dAppendS :: (OS.Shape sh, KnownNat m, KnownNat n)
-           => TensorS (m ': sh) r -> TensorS (n ': sh) r
-           -> TensorS ((m + n) ': sh) r
+           => TensorS r (m ': sh) -> TensorS r (n ': sh)
+           -> TensorS r ((m + n) ': sh)
   dSliceS :: (KnownNat i, KnownNat n, KnownNat k, OS.Shape rest)
-          => Proxy i -> Proxy n -> TensorS (i + n + k ': rest) r
-          -> TensorS (n ': rest) r
+          => Proxy i -> Proxy n -> TensorS r (i + n + k ': rest)
+          -> TensorS r (n ': rest)
   dIndexS :: (KnownNat ix, KnownNat k, OS.Shape rest)
-          => TensorS (ix + 1 + k ': rest) r -> Proxy ix -> TensorS rest r
+          => TensorS r (ix + 1 + k ': rest) -> Proxy ix -> TensorS r rest
   dRavelFromListS :: (KnownNat k, OS.Shape rest)
-                  => [TensorS rest r] -> TensorS (k : rest) r
+                  => [TensorS r rest] -> TensorS r (k : rest)
   dReshapeS :: (OS.Shape sh, OS.Shape sh', OS.Size sh ~ OS.Size sh')
-            => TensorS sh r -> TensorS sh' r
-  dFrom0S :: r -> TensorS '[] r
-  dFrom1S :: KnownNat n => Tensor1 r -> TensorS '[n] r
+            => TensorS r sh -> TensorS r sh'
+  dFrom0S :: r -> TensorS r '[]
+  dFrom1S :: KnownNat n => Tensor1 r -> TensorS r '[n]
   dFrom2S :: (KnownNat rows, KnownNat cols)
-          => Proxy cols -> Tensor2 r -> TensorS '[rows, cols] r
-  dFromXS :: OS.Shape sh => TensorX r -> TensorS sh r
+          => Proxy cols -> Tensor2 r -> TensorS r '[rows, cols]
+  dFromXS :: OS.Shape sh => TensorX r -> TensorS r sh
 
 
 -- * Backprop gradient method instances
@@ -237,7 +237,7 @@ instance HasRanks (Delta0 r) where
   type Tensor1 (Delta0 r) = Delta1 r
   type Tensor2 (Delta0 r) = Delta2 r
   type TensorX (Delta0 r) = DeltaX r
-  type TensorS sh (Delta0 r) = DeltaS r sh
+  type TensorS (Delta0 r) sh = DeltaS r sh
   dSumElements0 = SumElements0
   dIndex0 = Index0
   dDot0 = Dot0
@@ -399,7 +399,7 @@ instance HasRanks Double where
   type Tensor1 Double = Vector Double
   type Tensor2 Double = Matrix Double
   type TensorX Double = OT.Array Double
-  type TensorS sh Double = OS.Array sh Double
+  type TensorS Double sh = OS.Array sh Double
   dSumElements0 vd _ = HM.sumElements vd
   dIndex0 d ix _ = d V.! ix
   dDot0 = (HM.<.>)
@@ -470,7 +470,7 @@ instance HasRanks Float where
   type Tensor1 Float = Vector Float
   type Tensor2 Float = Matrix Float
   type TensorX Float = OT.Array Float
-  type TensorS sh Float = OS.Array sh Float
+  type TensorS Float sh = OS.Array sh Float
   -- Below it's completely repeated after the @Double@ case.
   dSumElements0 vd _ = HM.sumElements vd
   dIndex0 d ix _ = d V.! ix

--- a/src/HordeAd/Core/DualClass.hs
+++ b/src/HordeAd/Core/DualClass.hs
@@ -237,7 +237,7 @@ instance HasRanks (Delta0 r) where
   type Tensor1 (Delta0 r) = Delta1 r
   type Tensor2 (Delta0 r) = Delta2 r
   type TensorX (Delta0 r) = DeltaX r
-  type TensorS sh (Delta0 r) = DeltaS sh r
+  type TensorS sh (Delta0 r) = DeltaS r sh
   dSumElements0 = SumElements0
   dIndex0 = Index0
   dDot0 = Dot0
@@ -326,13 +326,13 @@ instance IsDual (DeltaX r) where
   {-# INLINE bindInState #-}
   bindInState = bindInStateX
 
-instance OS.Shape sh => IsDual (DeltaS sh r) where
-  type Primal (DeltaS sh r) = OS.Array sh r
+instance OS.Shape sh => IsDual (DeltaS r sh) where
+  type Primal (DeltaS r sh) = OS.Array sh r
   dZero = ZeroS
   dScale = ScaleS
   dAdd = AddS
   dVar = VarS
-  type ScalarOf (DeltaS sh r) = r
+  type ScalarOf (DeltaS r sh) = r
   {-# INLINE bindInState #-}
   bindInState u' st = let (st2, did) = bindInStateX (FromSX u') st
                       in (st2, covertDeltaId did)

--- a/src/HordeAd/Core/DualNumber.hs
+++ b/src/HordeAd/Core/DualNumber.hs
@@ -755,13 +755,10 @@ conv2S ker x = from2S $ conv2' (fromS2 ker) (fromS2 x)
 -- https://www.tensorflow.org/api_docs/python/tf/nn/conv2d
 conv24 :: forall filter_height_1 filter_width_1
                  out_channels in_height in_width n_batches in_channels r.
-          ( IsScalarS4 r out_channels in_channels
-                         (filter_height_1 + 1) (filter_width_1 + 1)
-          , IsScalarS4 r n_batches in_channels in_height in_width
-          , IsScalarS4 r n_batches out_channels
-                         (in_height + filter_height_1)
-                         (in_width + filter_width_1)
-          )
+          ( KnownNat filter_height_1, KnownNat filter_width_1
+          , KnownNat out_channels, KnownNat in_height, KnownNat in_width
+          , KnownNat n_batches, KnownNat in_channels
+          , IsScalarS r )
        => DualNumber (TensorS r '[ out_channels, in_channels
                                  , filter_height_1 + 1, filter_width_1 + 1 ])
        -> DualNumber (TensorS r '[n_batches, in_channels, in_height, in_width])
@@ -828,10 +825,10 @@ maxPool2 ksize stride m@(D u _) = do
 
 maxPool24 :: forall r m n_batches channels
                     in_height in_width out_height out_width.
-             ( DualMonad r m
-             , IsScalarS4 r n_batches channels in_height in_width
-             , IsScalarS4 r n_batches channels out_height out_width
-             )
+             ( KnownNat n_batches, KnownNat channels
+             , KnownNat in_height, KnownNat in_width
+             , KnownNat out_height, KnownNat out_width
+             , DualMonad r m, IsScalarS r )
           => Int -> Int
           -> DualNumber (TensorS r '[ n_batches, channels
                                     , in_height, in_width ])

--- a/src/HordeAd/Core/PairOfVectors.hs
+++ b/src/HordeAd/Core/PairOfVectors.hs
@@ -68,7 +68,7 @@ varX :: IsScalar r => DualNumberVariables r -> Int -> DualNumber (TensorX r)
 varX (_, _, _, _, _, _, vValue, vVar) i = D (vValue V.! i) (vVar V.! i)
 
 varS :: IsScalarS sh r
-     => DualNumberVariables r -> Int -> DualNumber (TensorS sh r)
+     => DualNumberVariables r -> Int -> DualNumber (TensorS r sh)
 varS (_, _, _, _, _, _, vValue, vVar) i =
   D (Data.Array.Convert.convert $ vValue V.! i) (dFromXS $ vVar V.! i)
 

--- a/src/HordeAd/Core/PairOfVectors.hs
+++ b/src/HordeAd/Core/PairOfVectors.hs
@@ -17,6 +17,7 @@ module HordeAd.Core.PairOfVectors
 import Prelude
 
 import qualified Data.Array.Convert
+import qualified Data.Array.ShapedS as OS
 import qualified Data.Strict.Vector as Data.Vector
 import qualified Data.Vector.Generic as V
 
@@ -67,7 +68,7 @@ var2 (_, _, _, _, vValue, vVar, _, _) i = D (vValue V.! i) (vVar V.! i)
 varX :: IsScalar r => DualNumberVariables r -> Int -> DualNumber (TensorX r)
 varX (_, _, _, _, _, _, vValue, vVar) i = D (vValue V.! i) (vVar V.! i)
 
-varS :: IsScalarS sh r
+varS :: (IsScalarS r, OS.Shape sh)
      => DualNumberVariables r -> Int -> DualNumber (TensorS r sh)
 varS (_, _, _, _, _, _, vValue, vVar) i =
   D (Data.Array.Convert.convert $ vValue V.! i) (dFromXS $ vVar V.! i)

--- a/src/HordeAd/Internal/Delta.hs
+++ b/src/HordeAd/Internal/Delta.hs
@@ -98,7 +98,7 @@ data Delta0 r =
   | Dot0 (Vector r) (Delta1 r)  -- ^ Dot0 v vd == SumElements0 (Scale1 v vd) n
 
   | FromX0 (DeltaX r)  -- ^ one of many conversions
-  | FromS0 (DeltaS '[] r)
+  | FromS0 (DeltaS r '[])
 
 deriving instance (Show r, Numeric r) => Show (Delta0 r)
 
@@ -124,13 +124,13 @@ data Delta1 r =
 
   | FromX1 (DeltaX r)
   | forall len. KnownNat len
-    => FromS1 (DeltaS '[len] r)
+    => FromS1 (DeltaS r '[len])
 
   | Reverse1 (Delta1 r)
   | Flatten1 Int Int (Delta2 r)
   | FlattenX1 OT.ShapeL (DeltaX r)
   | forall sh. OS.Shape sh
-    => FlattenS1 (DeltaS sh r)
+    => FlattenS1 (DeltaS r sh)
 
 deriving instance (Show r, Numeric r) => Show (Delta1 r)
 
@@ -158,7 +158,7 @@ data Delta2 r =
 
   | FromX2 (DeltaX r)
   | forall rows cols. (KnownNat rows, KnownNat cols)
-    => FromS2 (DeltaS '[rows, cols] r)
+    => FromS2 (DeltaS r '[rows, cols])
 
   | Flipud2 (Delta2 r)
   | Fliprl2 (Delta2 r)
@@ -197,7 +197,7 @@ data DeltaX r =
   | From1X (Delta1 r)
   | From2X (Delta2 r) Int
   | forall sh. OS.Shape sh
-    => FromSX (DeltaS sh r)
+    => FromSX (DeltaS r sh)
 
 deriving instance (Show r, Numeric r) => Show (DeltaX r)
 
@@ -205,38 +205,38 @@ deriving instance (Show r, Numeric r) => Show (DeltaX r)
 -- the fully typed Shaped version.
 --
 -- Warning: not tested enough nor benchmarked.
-data DeltaS :: [Nat] -> Type -> Type where
-  ZeroS :: DeltaS sh r
-  ScaleS :: OS.Array sh r -> DeltaS sh r -> DeltaS sh r
-  AddS :: DeltaS sh r -> DeltaS sh r -> DeltaS sh r
-  VarS :: DeltaId (OS.Array sh r) -> DeltaS sh r
+data DeltaS :: Type -> [Nat] -> Type where
+  ZeroS :: DeltaS r sh
+  ScaleS :: OS.Array sh r -> DeltaS r sh -> DeltaS r sh
+  AddS :: DeltaS r sh -> DeltaS r sh -> DeltaS r sh
+  VarS :: DeltaId (OS.Array sh r) -> DeltaS r sh
 
-  KonstS :: Delta0 r -> DeltaS sh r
+  KonstS :: Delta0 r -> DeltaS r sh
   AppendS :: (OS.Shape sh, KnownNat m, KnownNat n)
-          => DeltaS (m ': sh) r -> DeltaS (n ': sh) r
-          -> DeltaS ((m + n) ': sh) r
+          => DeltaS r (m ': sh) -> DeltaS r (n ': sh)
+          -> DeltaS r ((m + n) ': sh)
     -- ^ Append two arrays along the outermost dimension.
   SliceS :: (KnownNat i, KnownNat n, KnownNat k, OS.Shape rest)
-         => Proxy i -> Proxy n -> DeltaS (i + n + k ': rest) r
-         -> DeltaS (n ': rest) r
+         => Proxy i -> Proxy n -> DeltaS r (i + n + k ': rest)
+         -> DeltaS r (n ': rest)
     -- ^ Extract a slice of an array along the outermost dimension.
   IndexS :: (KnownNat ix, KnownNat k, OS.Shape rest)
-         => DeltaS (ix + 1 + k ': rest) r -> Proxy ix -> DeltaS rest r
+         => DeltaS r (ix + 1 + k ': rest) -> Proxy ix -> DeltaS r rest
     -- ^ The sub-tensors at the given index of the outermost dimension.
   RavelFromListS :: (KnownNat k, OS.Shape rest)
-                 => [DeltaS rest r] -> DeltaS (k : rest) r
+                 => [DeltaS r rest] -> DeltaS r (k : rest)
     -- ^ Create a tensor from a list treated as the outermost dimension.
   ReshapeS :: (OS.Shape sh, OS.Shape sh', OS.Size sh ~ OS.Size sh')
-           => DeltaS sh r -> DeltaS sh' r
+           => DeltaS r sh -> DeltaS r sh'
     -- ^ Change the shape of the tensor.
 
-  From0S :: Delta0 r -> DeltaS '[] r
-  From1S :: Delta1 r -> DeltaS '[n] r
+  From0S :: Delta0 r -> DeltaS r '[]
+  From1S :: Delta1 r -> DeltaS r '[n]
   From2S :: KnownNat cols
-         => Proxy cols -> Delta2 r -> DeltaS '[rows, cols] r
-  FromXS :: DeltaX r -> DeltaS sh r
+         => Proxy cols -> Delta2 r -> DeltaS r '[rows, cols]
+  FromXS :: DeltaX r -> DeltaS r sh
 
-instance Show (DeltaS sh r) where
+instance Show (DeltaS r sh) where
   show _ = "a DeltaS delta expression"
 
 
@@ -585,7 +585,7 @@ buildFinMaps st deltaTopLevel dt = do
                 d
         FromSX d -> evalS (Data.Array.Convert.convert r) d
       evalS :: OS.Shape sh
-            => OS.Array sh r -> DeltaS sh r -> ST s ()
+            => OS.Array sh r -> DeltaS r sh -> ST s ()
       evalS !r = \case
         ZeroS -> return ()
         ScaleS k d -> evalS (OS.zipWithA (*) k r) d
@@ -593,15 +593,15 @@ buildFinMaps st deltaTopLevel dt = do
         VarS (DeltaId i) -> VM.modify finMapX (addToArrayS r) i
 
         KonstS d -> mapM_ (`eval0` d) $ OS.toList r
-        AppendS (d :: DeltaS (k ': rest) r) (e :: DeltaS (l ': rest) r) ->
+        AppendS (d :: DeltaS r (k ': rest)) (e :: DeltaS r (l ': rest)) ->
           evalS (OS.slice @'[ '(0, k) ] r) d
           >> evalS (OS.slice @'[ '(k, l) ] r) e
-        SliceS (_ :: Proxy i) _ (d :: DeltaS (i_plus_n_plus_k ': rest) r) ->
+        SliceS (_ :: Proxy i) _ (d :: DeltaS r (i_plus_n_plus_k ': rest)) ->
           evalS (OS.constant @(i ': rest) 0
                  `OS.append` r
                  `OS.append` OS.constant 0)
                 d
-        IndexS (d :: DeltaS (ix_plus_1_plus_k ': rest) r) (_ :: Proxy ix) ->
+        IndexS (d :: DeltaS r (ix_plus_1_plus_k ': rest)) (_ :: Proxy ix) ->
           evalS (OS.constant @(ix ': rest) 0
                  `OS.append` OS.reshape r
                  `OS.append` OS.constant 0)
@@ -760,7 +760,7 @@ derivativeFromDelta st deltaTopLevel
         From2X d cols -> let l = eval2 parameters d
                          in OT.fromVector [HM.rows l, cols] $ HM.flatten l
         FromSX d -> Data.Array.Convert.convert $ evalS parameters d
-      evalS :: OS.Shape sh => Domains r -> DeltaS sh r -> OS.Array sh r
+      evalS :: OS.Shape sh => Domains r -> DeltaS r sh -> OS.Array sh r
       evalS parameters@( _, _, _, paramsX) = \case
         ZeroS -> 0
         ScaleS k d -> k * evalS parameters d

--- a/test/TestMnistCNN.hs
+++ b/test/TestMnistCNN.hs
@@ -10,7 +10,7 @@ import           Data.Array.Internal (valueOf)
 import qualified Data.Array.ShapedS as OS
 import           Data.Proxy (Proxy (Proxy))
 import qualified Data.Vector.Generic as V
-import           GHC.TypeLits (type (+))
+import           GHC.TypeLits (KnownNat, type (+))
 import qualified Numeric.LinearAlgebra as HM
 import           System.Random
 import           Test.Tasty
@@ -357,17 +357,11 @@ convMiddleMnistCNNT
   :: forall filter_height_1 filter_width_1 out_channels
             in_height in_width out_height out_width
             n_batches in_channels r m.
-     ( DualMonad r m
-     , IsScalarS4 r n_batches in_channels in_height in_width
-     , IsScalarS4 r n_batches in_channels
-                    (in_height + filter_height_1) (in_width + filter_width_1)
-     , IsScalarS4 r n_batches out_channels
-                    (in_height + filter_height_1) (in_width + filter_width_1)
-     , IsScalarS4 r n_batches out_channels out_height out_width
-     , IsScalarS4 r out_channels in_channels
-                    (filter_height_1 + 1) (filter_width_1 + 1)
-     , IsScalarS1 r out_channels
-     )
+     ( KnownNat filter_height_1, KnownNat filter_width_1, KnownNat out_channels
+     , KnownNat in_height, KnownNat in_width
+     , KnownNat out_height, KnownNat out_width
+     , KnownNat n_batches, KnownNat in_channels
+     , DualMonad r m, IsScalarS r )
   => DualNumberVariables r
   -> DualNumber (TensorS r '[ n_batches, in_channels
                             , in_height, in_width ])
@@ -394,24 +388,12 @@ convMnistCNNT
   :: forall filter_height_1 filter_width_1
             in_height in_width out_height out_width out2_height out2_width
             in_channels out_channels n_batches r m.
-     ( DualMonad r m
-     , IsScalarS4 r n_batches in_channels
-                    (in_height + filter_height_1) (in_width + filter_width_1)
-     , IsScalarS4 r n_batches out_channels out_height out_width
-     , IsScalarS4 r out_channels in_channels
-                    (filter_height_1 + 1) (filter_width_1 + 1)
-     , IsScalarS1 r out_channels
-     , IsScalarS4 r n_batches in_channels in_height in_width
-     , IsScalarS4 r n_batches out_channels out2_height out2_width
-     , IsScalarS4 r out_channels out_channels
-                    (filter_height_1 + 1) (filter_width_1 + 1)
-     , IsScalarS4 r n_batches out_channels
-                    (in_height + filter_height_1) (in_width + filter_width_1)
-     , IsScalarS4 r n_batches out_channels
-                    (out_height + filter_height_1)
-                    (out_width + filter_width_1)
-     , IsScalarS2 r n_batches (OS.Size '[out_channels, out2_height, out2_width])
-     )
+     ( KnownNat filter_height_1, KnownNat filter_width_1, KnownNat out_channels
+     , KnownNat in_height, KnownNat in_width
+     , KnownNat out_height, KnownNat out_width
+     , KnownNat out2_height, KnownNat out2_width
+     , KnownNat n_batches, KnownNat in_channels
+     , DualMonad r m, IsScalarS r )
   => Primal (TensorS r '[n_batches, in_channels, in_height, in_width])
   -> DualNumberVariables r
   -> m (DualNumber (Tensor2 r))
@@ -440,24 +422,12 @@ convMnistLossCNNTPoly
   :: forall filter_height_1 filter_width_1
             in_height in_width out_height out_width out2_height out2_width
             in_channels out_channels n_batches r m.
-     ( DualMonad r m, Floating (Primal (Tensor2 r))
-     , IsScalarS4 r n_batches in_channels
-                    (in_height + filter_height_1) (in_width + filter_width_1)
-     , IsScalarS4 r n_batches out_channels out_height out_width
-     , IsScalarS4 r out_channels in_channels
-                    (filter_height_1 + 1) (filter_width_1 + 1)
-     , IsScalarS4 r n_batches in_channels in_height in_width
-     , IsScalarS4 r n_batches out_channels out2_height out2_width
-     , IsScalarS4 r out_channels out_channels
-                    (filter_height_1 + 1) (filter_width_1 + 1)
-     , IsScalarS4 r n_batches out_channels
-                    (in_height + filter_height_1) (in_width + filter_width_1)
-     , IsScalarS4 r n_batches out_channels
-                    (out_height + filter_height_1)
-                    (out_width + filter_width_1)
-     , IsScalarS2 r n_batches (OS.Size '[out_channels, out2_height, out2_width])
-     , IsScalarS1 r out_channels
-     )
+     ( KnownNat filter_height_1, KnownNat filter_width_1, KnownNat out_channels
+     , KnownNat in_height, KnownNat in_width
+     , KnownNat out_height, KnownNat out_width
+     , KnownNat out2_height, KnownNat out2_width
+     , KnownNat n_batches, KnownNat in_channels
+     , DualMonad r m, IsScalarS r, Floating (Primal (Tensor2 r)) )
   => [MnistData2 (Primal r)]
   -> DualNumberVariables r
   -> m (DualNumber r)
@@ -477,22 +447,7 @@ convMnistLossCNNT
   :: forall filter_height_1 filter_width_1
             in_height in_width out_height out_width out2_height out2_width
             in_channels out_channels n_batches r m.
-     ( DualMonad r m, Floating (Primal (Tensor2 r))
-     , IsScalarS4 r n_batches in_channels
-                    (in_height + filter_height_1) (in_width + filter_width_1)
-     , IsScalarS4 r n_batches out_channels out_height out_width
-     , IsScalarS4 r out_channels in_channels
-                    (filter_height_1 + 1) (filter_width_1 + 1)
-     , IsScalarS4 r n_batches in_channels in_height in_width
-     , IsScalarS4 r n_batches out_channels out2_height out2_width
-     , IsScalarS4 r out_channels out_channels
-                    (filter_height_1 + 1) (filter_width_1 + 1)
-     , IsScalarS4 r n_batches out_channels
-                    (in_height + filter_height_1) (in_width + filter_width_1)
-     , IsScalarS4 r n_batches out_channels
-                    (out_height + filter_height_1)
-                    (out_width + filter_width_1)
-     , IsScalarS2 r n_batches (OS.Size '[out_channels, out2_height, out2_width])
+     ( DualMonad r m, IsScalarS r, Floating (Primal (Tensor2 r))
      , n_batches ~ 16
      , out_channels ~ 16
      , filter_height_1 ~ 4
@@ -518,24 +473,12 @@ convMnistTestCNNTPoly
   :: forall filter_height_1 filter_width_1
             in_height in_width out_height out_width out2_height out2_width
             in_channels out_channels n_batches r.
-     ( Floating (Primal (Tensor1 r))
-     , IsScalarS4 r n_batches in_channels
-                    (in_height + filter_height_1) (in_width + filter_width_1)
-     , IsScalarS4 r n_batches out_channels out_height out_width
-     , IsScalarS4 r out_channels in_channels
-                    (filter_height_1 + 1) (filter_width_1 + 1)
-     , IsScalarS4 r n_batches in_channels in_height in_width
-     , IsScalarS4 r n_batches out_channels out2_height out2_width
-     , IsScalarS4 r out_channels out_channels
-                    (filter_height_1 + 1) (filter_width_1 + 1)
-     , IsScalarS4 r n_batches out_channels
-                    (in_height + filter_height_1) (in_width + filter_width_1)
-     , IsScalarS4 r n_batches out_channels
-                    (out_height + filter_height_1)
-                    (out_width + filter_width_1)
-     , IsScalarS2 r n_batches (OS.Size '[out_channels, out2_height, out2_width])
-     , IsScalarS1 r out_channels
-     )
+     ( KnownNat filter_height_1, KnownNat filter_width_1, KnownNat out_channels
+     , KnownNat in_height, KnownNat in_width
+     , KnownNat out_height, KnownNat out_width
+     , KnownNat out2_height, KnownNat out2_width
+     , KnownNat n_batches, KnownNat in_channels
+     , IsScalarS r, Floating (Primal (Tensor1 r)) )
   => Proxy r -> [MnistData2 (Primal r)] -> Domains r -> Primal r
 convMnistTestCNNTPoly _ inputs parameters =
   let matchesLabels :: MnistData2 (Primal r) -> Bool
@@ -561,22 +504,7 @@ convMnistTestCNNT
   :: forall filter_height_1 filter_width_1
             in_height in_width out_height out_width out2_height out2_width
             in_channels out_channels n_batches r.
-     ( Floating (Primal (Tensor1 r))
-     , IsScalarS4 r n_batches in_channels
-                    (in_height + filter_height_1) (in_width + filter_width_1)
-     , IsScalarS4 r n_batches out_channels out_height out_width
-     , IsScalarS4 r out_channels in_channels
-                    (filter_height_1 + 1) (filter_width_1 + 1)
-     , IsScalarS4 r n_batches in_channels in_height in_width
-     , IsScalarS4 r n_batches out_channels out2_height out2_width
-     , IsScalarS4 r out_channels out_channels
-                    (filter_height_1 + 1) (filter_width_1 + 1)
-     , IsScalarS4 r n_batches out_channels
-                    (in_height + filter_height_1) (in_width + filter_width_1)
-     , IsScalarS4 r n_batches out_channels
-                    (out_height + filter_height_1)
-                    (out_width + filter_width_1)
-     , IsScalarS2 r n_batches (OS.Size '[out_channels, out2_height, out2_width])
+     ( IsScalarS r, Floating (Primal (Tensor1 r))
      , n_batches ~ 1
      , out_channels ~ 16
      , filter_height_1 ~ 4

--- a/test/TestMnistCNN.hs
+++ b/test/TestMnistCNN.hs
@@ -369,19 +369,19 @@ convMiddleMnistCNNT
      , IsScalarS1 r out_channels
      )
   => DualNumberVariables r
-  -> DualNumber (TensorS '[ n_batches, in_channels
-                          , in_height, in_width ] r)
+  -> DualNumber (TensorS r '[ n_batches, in_channels
+                            , in_height, in_width ])
   -> Int
-  -> m (DualNumber (TensorS '[ n_batches
-                             , out_channels, out_height, out_width ] r))
+  -> m (DualNumber (TensorS r '[ n_batches
+                               , out_channels, out_height, out_width ]))
 convMiddleMnistCNNT variables x offset = do
   let ker = varS variables offset
       yConv = conv24 ker x
       bias = varS variables $ offset + 2
       replicateBias
-        :: DualNumber (TensorS '[] r)
-           -> DualNumber (TensorS '[ in_height + filter_height_1
-                                   , in_width + filter_width_1 ] r)
+        :: DualNumber (TensorS r '[])
+           -> DualNumber (TensorS r '[ in_height + filter_height_1
+                                     , in_width + filter_width_1 ])
       replicateBias = konstS . fromS0
       biasStretched = ravelFromListS
                       $ replicate (valueOf @n_batches)
@@ -412,7 +412,7 @@ convMnistCNNT
                     (out_width + filter_width_1)
      , IsScalarS2 r n_batches (OS.Size '[out_channels, out2_height, out2_width])
      )
-  => Primal (TensorS '[n_batches, in_channels, in_height, in_width] r)
+  => Primal (TensorS r '[n_batches, in_channels, in_height, in_width])
   -> DualNumberVariables r
   -> m (DualNumber (Tensor2 r))
 convMnistCNNT x variables = do
@@ -463,7 +463,7 @@ convMnistLossCNNTPoly
   -> m (DualNumber r)
 convMnistLossCNNTPoly lmnistData variables = do
   let (lx, ltarget) = unzip lmnistData
-      tx :: Primal (TensorS '[n_batches, in_channels, in_height, in_width] r)
+      tx :: Primal (TensorS r '[n_batches, in_channels, in_height, in_width])
       tx = OS.fromList $ concatMap (HM.toList . HM.flatten) lx
   result <- convMnistCNNT @filter_height_1 @filter_width_1
                           @in_height @in_width @out_height @out_width
@@ -540,8 +540,8 @@ convMnistTestCNNTPoly
 convMnistTestCNNTPoly _ inputs parameters =
   let matchesLabels :: MnistData2 (Primal r) -> Bool
       matchesLabels (glyph, label) =
-        let tx :: Primal (TensorS '[ n_batches, in_channels
-                                   , in_height, in_width ] r)
+        let tx :: Primal (TensorS r '[ n_batches, in_channels
+                                     , in_height, in_width ])
             tx = OS.fromVector $ HM.flatten glyph
             nn :: DualNumberVariables r
                -> DualMonadValue r (DualNumber (Tensor1 r))


### PR DESCRIPTION
Fixes #25. The main commit is [Inline PrimalS, hack the rest to hang on](https://github.com/Mikolaj/horde-ad/commit/2b8a9ea618569bd4db7eef2731aa0aef02205174).

Removal of the spurious constraints is accomplished by defining class `IsDualS`, as sketched by @simonpj, analogous to the existing `IsDual` class, but for types parameterized by shape. Since the `~` type equality does not work for higher kind types, we can't create type family `PrimalS` in class `IsDualS` analogous to `Primal` in the `IsDual` class. Therefore, we effectively inline `PrimalS` (but not `Primal` from the `IsDual` class!). The trick is completed by defining an instance of  `IsDual` constructed based on `IsDualS`, which is again a mechanism suggested by @simonpj, though in that early prototype it was based on a quantified constraint, which doesn't seem to work, while the instance (barely) works.

The instance requires `IncoherentInstances` to work in GHC 9.2.2 and random code changes break it. In particular, I had to revert a simplification of `HordeAd.Core.DualClass` that broke type-checking due to the fragility. It seems to work perfectly in GHC HEAD, but type-level plugins don't, so I can't test the full codebase in HEAD and confirm.

Against all odds, not even one of the calamities I predicted materialized. The API of `HordeAd.Core.DualClass` was not split/cloned for the case of shaped tensors. If fact, it's even more regular than before (or would be, if the simplification was not reverted), even though the implementation has some extra complexity. Surprisingly, no code duplication was needed either in user code nor in implementation of the API, despite a new class and the necessity to define a newtype to change the order of parameters to partially apply a type at the second parameter (the underlying scalar type, leaving the shape not applied).

We apparently managed to create the best of both worlds: the constraint in a type signature is given only once, using the higher-kinded `IsDualS` under the hood, while all the types are written using fully applied (to multiple shapes!) mechanisms from the regular classes `IsDual` and `HasRanks` that are used also for vectors, untyped tensors, etc. Even the inlining of `PrimalS` is not visible in the API, because `IsDualS` is not exported and the not inlined `Primal` from `IsDual` agrees in all concrete cases and can't observe/express the higher-kinded cases.
