### PR TITLE
Weaken IsDualWithScalar for returnLet

### DIFF
--- a/src/HordeAd/Core/DualClass.hs
+++ b/src/HordeAd/Core/DualClass.hs
@@ -9,7 +9,7 @@
 -- used to define types and operations in "HordeAd.Core.DualNumber"
 -- that is the high-level API.
 module HordeAd.Core.DualClass
-  ( IsDualWithScalar, IsScalar, HasDelta, HasForward
+  ( IsDualWithScalar, IsDualWithScalarWeaker, IsScalar, HasDelta, HasForward
   , IsDual(dZero, dScale, dAdd)
   , HasVariables(dVar, bindInState)
   , DifferentiationScheme(..), Dual, HasRanks(..)
@@ -44,6 +44,9 @@ import HordeAd.Internal.Delta
 type IsDualWithScalar (d :: DifferentiationScheme) a r =
   ( IsDual d a, HasVariables a r
   , Floating a, MonoFunctor a, Element a ~ r )
+
+type IsDualWithScalarWeaker (d :: DifferentiationScheme) a r =
+  ( IsDual d a, HasVariables a r )
 
 -- | A mega-shorthand for a bundle of connected type constraints.
 type IsScalar (d :: DifferentiationScheme) r =

--- a/src/HordeAd/Core/DualNumber.hs
+++ b/src/HordeAd/Core/DualNumber.hs
@@ -42,7 +42,7 @@ data DualNumber (d :: DifferentiationScheme) a = D a (Dual d a)
 
 class (IsScalar d r, Monad m, Functor m, Applicative m)
       => DualMonad d r m | m -> d r where
-  returnLet :: IsDualWithScalar d a r
+  returnLet :: IsDualWithScalarWeaker d a r
             => DualNumber d a -> m (DualNumber d a)
 
 addParameters :: (Numeric r, Num (Vector r))

--- a/src/HordeAd/Core/Engine.hs
+++ b/src/HordeAd/Core/Engine.hs
@@ -27,6 +27,7 @@ import HordeAd.Core.DualClass
   , Dual
   , HasVariables (bindInState, dVar)
   , IsDual (..)
+  , IsDualWithScalarWeaker
   )
 import HordeAd.Core.DualNumber
 import HordeAd.Core.PairOfVectors (DualNumberVariables, makeDualNumberVariables)
@@ -95,7 +96,7 @@ newtype DualMonadGradient r a = DualMonadGradient
 instance IsScalar 'DifferentiationSchemeGradient r
          => DualMonad 'DifferentiationSchemeGradient
                       r (DualMonadGradient r) where
-  returnLet :: forall a. IsDualWithScalar 'DifferentiationSchemeGradient a r
+  returnLet :: forall a. IsDualWithScalarWeaker 'DifferentiationSchemeGradient a r
             => DualNumber 'DifferentiationSchemeGradient a
             -> DualMonadGradient r (DualNumber 'DifferentiationSchemeGradient a)
   returnLet (D u u') = DualMonadGradient $ do


### PR DESCRIPTION
This avoids asking more than necessary of the callers of `returnLet`.