### PR TITLE
Voice recognition (fixes #58)

### DIFF
--- a/horde-ad.cabal
+++ b/horde-ad.cabal
@@ -204,6 +204,8 @@ library testLibrary
     -- Other library packages from which modules are imported.
     build-depends:
         base
+      , cereal
+      , bytestring
       , deepseq
       , HUnit-approx
       , hmatrix

--- a/horde-ad.cabal
+++ b/horde-ad.cabal
@@ -196,6 +196,7 @@ library testLibrary
     exposed-modules:  TestMnistCNN
                       TestMnistFCNN
                       TestMnistRNN
+                      TestSpeechRNN
                       TestSimpleDescent
                       TestSingleGradient
   }

--- a/horde-ad.cabal
+++ b/horde-ad.cabal
@@ -204,9 +204,10 @@ library testLibrary
     -- Other library packages from which modules are imported.
     build-depends:
         base
-      , cereal
       , bytestring
+      , cereal
       , deepseq
+      , directory
       , HUnit-approx
       , hmatrix
       , horde-ad

--- a/src/HordeAd/Core/Optimizer.hs
+++ b/src/HordeAd/Core/Optimizer.hs
@@ -5,6 +5,7 @@ module HordeAd.Core.Optimizer
   , sgd
   , sgdAdam, sgdAdamArgs
   , StateAdam, initialStateAdam
+  , mapDomains
   ) where
 
 import Prelude

--- a/src/HordeAd/Internal/OrthotopeOrphanInstances.hs
+++ b/src/HordeAd/Internal/OrthotopeOrphanInstances.hs
@@ -15,9 +15,9 @@ import           Numeric.LinearAlgebra (Matrix, Numeric, Vector)
 import qualified Numeric.LinearAlgebra as HM
 import qualified Numeric.LinearAlgebra.Devel
 
-liftVT :: Numeric r
-       => (Vector r -> Vector r)
-       -> OT.Array r -> OT.Array r
+liftVT :: (Numeric r1, Numeric r2)
+       => (Vector r1 -> Vector r2)
+       -> OT.Array r1 -> OT.Array r2
 liftVT op t = OT.fromVector (OT.shapeL t) $ op $ OT.toVector t
 
 liftVT2 :: Numeric r

--- a/test/ExtremelyLongTest.hs
+++ b/test/ExtremelyLongTest.hs
@@ -24,6 +24,7 @@ import qualified TestMnistFCNN
 import qualified TestMnistRNN
 import qualified TestSimpleDescent
 import qualified TestSingleGradient
+import qualified TestSpeechRNN
 #endif
 
 main :: IO ()
@@ -46,5 +47,6 @@ tests = testGroup "Tests" $
   ++ TestSimpleDescent.testTrees
   ++ TestMnistFCNN.testTrees
   ++ TestMnistRNN.testTrees
+  ++ TestSpeechRNN.testTrees
   ++ TestMnistCNN.testTrees
 #endif

--- a/test/ShortTestForCI.hs
+++ b/test/ShortTestForCI.hs
@@ -21,6 +21,7 @@ import qualified TestMnistFCNN
 import qualified TestMnistRNN
 import qualified TestSimpleDescent
 import qualified TestSingleGradient
+import qualified TestSpeechRNN
 #endif
 
 main :: IO ()
@@ -41,6 +42,7 @@ tests = testGroup "Short tests for CI" $
   ++ TestSimpleDescent.testTrees
   ++ TestMnistFCNN.shortTestForCITrees
   ++ TestMnistRNN.shortTestForCITrees
+  ++ TestSpeechRNN.shortTestForCITrees
   ++ TestMnistCNN.shortTestForCITrees
 #else
   []

--- a/test/common/TestSpeechRNN.hs
+++ b/test/common/TestSpeechRNN.hs
@@ -10,6 +10,8 @@ import           Control.Exception (assert)
 import           Control.Monad (foldM)
 import qualified Data.Array.DynamicS as OT
 import           Data.Array.Internal (valueOf)
+import qualified Data.Array.Shape
+import qualified Data.Array.Shaped as OSB
 import qualified Data.Array.ShapedS as OS
 import qualified Data.ByteString.Lazy as LBS
 import           Data.List (foldl', unfoldr)
@@ -30,6 +32,11 @@ import           Text.Printf
 import qualified GHC.TypeLits
 
 import HordeAd
+import HordeAd.Tool.MnistData (chunksOf, shuffle)
+import HordeAd.Tool.MnistRnnShaped
+  (LayerWeigthsRNN, rnnMnistLayerS, unrollLastS, zeroStateS)
+
+import TestCommonEqEpsilon
 
 testTrees :: [TestTree]
 testTrees = [ mnistRNNTestsLong
@@ -44,12 +51,6 @@ shortTestForCITrees = [ speechRNNTestsShort
 type SpeechDataBatch batch_size block_size window_size n_labels r =
   ( OS.Array '[batch_size, block_size, window_size] r
   , OS.Array '[batch_size, n_labels] r )
-
-chunksOf :: Int -> [e] -> [[e]]
-chunksOf n = go where
-  go [] = []
-  go l = let (chunk, rest) = splitAt n l
-         in chunk : go rest
 
 -- The last chunk is thrown away if smaller than batch size.
 -- It crashes if the size of either file doesn't match the other.
@@ -87,7 +88,7 @@ decodeSpeechData soundsBs labelsBs =
       !_A3 = assert (length soundsChunks == length labelsChunks) ()
       makeSpeechDataBatch
         :: [r] -> [r]
-        -> SpeechDataBatch batch_size block_size  window_size n_labels r
+        -> SpeechDataBatch batch_size block_size window_size n_labels r
       makeSpeechDataBatch soundsCh labelsCh =
         let labelsBlockSize = valueOf @block_size * valueOf @n_labels
             labelsBlocks = chunksOf labelsBlockSize labelsCh
@@ -112,6 +113,124 @@ loadSpeechData soundsPath labelsPath =
       let !_A1 = assert (LBS.length soundsContents > 0) ()
       return $! decodeSpeechData soundsContents labelsContents
 
+
+rnnSpeechTwo
+  :: forall out_width batch_size window_size d r m.
+     ( DualMonad d r m, KnownNat out_width, KnownNat batch_size
+     , KnownNat window_size )
+  => DualNumber d (OS.Array '[2 GHC.TypeLits.* out_width, batch_size] r)
+       -- initial state
+  -> OS.Array '[window_size, batch_size] r
+  -> ( LayerWeigthsRNN window_size out_width d r
+     , LayerWeigthsRNN out_width out_width d r )
+  -> m ( DualNumber d (OS.Array '[out_width, batch_size] r)
+       , DualNumber d (OS.Array '[2 GHC.TypeLits.* out_width, batch_size] r) )
+           -- final state
+rnnSpeechTwo s x ((wX, wS, b), (wX2, wS2, b2)) = do
+  let s1 = sliceS @0 @out_width s
+      s2 = sliceS @out_width @out_width s
+  (vec1, s1') <- rnnMnistLayerS s1 (constant x) (wX, wS, b)
+  (vec2, s2') <- rnnMnistLayerS s2 vec1 (wX2, wS2, b2)
+  s3 <- returnLet $ appendS s1' s2'
+  return (vec2, s3)
+
+rnnSpeechZero
+  :: forall out_width batch_size block_size window_size n_labels d r m.
+     ( DualMonad d r m, KnownNat out_width, KnownNat batch_size
+     , KnownNat block_size, KnownNat window_size, KnownNat n_labels )
+  => OS.Array '[block_size, window_size, batch_size] r
+  -- All below is the type of all parameters of this nn. The same is reflected
+  -- in the length function below and read from variables further down.
+  -> ( LayerWeigthsRNN window_size out_width d r
+     , LayerWeigthsRNN out_width out_width d r )
+  -> DualNumber d (OS.Array '[n_labels, out_width] r)
+  -> DualNumber d (OS.Array '[n_labels] r)
+  -> m (DualNumber d (OS.Array '[n_labels, batch_size] r))
+rnnSpeechZero xs ((wX, wS, b), (wX2, wS2, b2)) w3 b3 = do
+  (out, _s) <- zeroStateS (unrollLastS rnnSpeechTwo) xs
+                          ((wX, wS, b), (wX2, wS2, b2))
+  returnLet $ w3 <>$ out + asColumnS b3
+
+rnnSpeechLen
+  :: forall out_width window_size n_labels.
+     (KnownNat out_width, KnownNat window_size, KnownNat n_labels)
+  => Proxy out_width -> Proxy window_size -> Proxy n_labels
+  -> (Int, [Int], [(Int, Int)], [OT.ShapeL])
+rnnSpeechLen _ _ _ =
+  ( 0
+  , []
+  , []
+  , [ Data.Array.Shape.shapeT @'[out_width, window_size]
+    , Data.Array.Shape.shapeT @'[out_width, out_width]
+    , Data.Array.Shape.shapeT @'[out_width]
+    , Data.Array.Shape.shapeT @'[out_width, out_width]
+    , Data.Array.Shape.shapeT @'[out_width, out_width]
+    , Data.Array.Shape.shapeT @'[out_width]
+    , Data.Array.Shape.shapeT @'[n_labels, out_width]
+    , Data.Array.Shape.shapeT @'[n_labels]
+    ]
+  )
+
+rnnSpeech
+  :: forall out_width batch_size block_size window_size n_labels d r m.
+     ( DualMonad d r m, KnownNat out_width, KnownNat batch_size
+     , KnownNat block_size, KnownNat window_size, KnownNat n_labels )
+  => OS.Array '[window_size, block_size, batch_size] r
+  -> DualNumberVariables d r
+  -> m (DualNumber d (OS.Array '[n_labels, batch_size] r))
+rnnSpeech xs variables = do
+  let wX = varS variables 0
+      wS = varS variables 1
+      b = varS variables 2
+      wX2 = varS variables 3
+      wS2 = varS variables 4
+      b2 = varS variables 5
+      w3 = varS variables 6
+      b3 = varS variables 7
+  rnnSpeechZero @out_width xs ((wX, wS, b), (wX2, wS2, b2)) w3 b3
+
+rnnSpeechLossFused
+  :: forall out_width batch_size block_size window_size n_labels d r m.
+     ( DualMonad d r m, KnownNat out_width, KnownNat batch_size
+     , KnownNat block_size, KnownNat window_size, KnownNat n_labels )
+  => Proxy out_width
+  -> SpeechDataBatch batch_size block_size window_size n_labels r
+  -> DualNumberVariables d r
+  -> m (DualNumber d r)
+rnnSpeechLossFused _ (sounds, labels) variables = do
+  let xs = OS.transpose @'[2, 1, 0] sounds
+  result <- rnnSpeech @out_width @batch_size @block_size @window_size @n_labels
+                      xs variables
+  let targets2 = HM.tr $ HM.reshape (valueOf @n_labels)
+                       $ OS.toVector labels
+  vec <- lossSoftMaxCrossEntropyL targets2 (fromS2 result)
+  returnLet $ scale (recip $ fromIntegral (valueOf @batch_size :: Int))
+            $ sumElements0 vec
+
+rnnSpeechTest
+  :: forall out_width batch_size block_size window_size n_labels d r m.
+     ( IsScalar 'DModeValue r, KnownNat out_width, KnownNat batch_size
+     , KnownNat block_size, KnownNat window_size, KnownNat n_labels )
+  => Proxy out_width
+  -> SpeechDataBatch batch_size block_size window_size n_labels r
+  -> Domains r
+  -> r
+rnnSpeechTest _ (sounds, labels) parameters =
+  let xs = OS.transpose @'[2, 1, 0] sounds
+      outputS =
+        primalValue
+           (rnnSpeech @out_width @batch_size @block_size @window_size @n_labels
+                      xs)
+           parameters
+      outputs = map OS.toVector $ OSB.toList $ OS.unravel
+                $ OS.transpose @'[1, 0] $ outputS
+      targets = map OS.toVector $ OSB.toList $ OS.unravel labels
+      matchesLabels :: Vector r -> Vector r -> Int
+      matchesLabels output label | V.maxIndex output == V.maxIndex label = 1
+                                 | otherwise = 0
+  in fromIntegral (sum (zipWith matchesLabels outputs targets))
+     / fromIntegral (valueOf @batch_size :: Int)
+
 speechTestCaseRNN
   :: forall out_width batch_size block_size window_size n_labels d r m.
      ( KnownNat out_width, KnownNat batch_size, KnownNat block_size
@@ -122,25 +241,76 @@ speechTestCaseRNN
   -> Int
   -> (forall out_width' batch_size' block_size' window_size' n_labels'.
       ( DualMonad d r m, KnownNat out_width', KnownNat batch_size'
-      , KnownNat block_size', KnownNat n_labels' )
+      , KnownNat block_size', KnownNat window_size', KnownNat n_labels' )
       => Proxy out_width'
       -> SpeechDataBatch batch_size' block_size' window_size' n_labels' r
       -> DualNumberVariables d r
       -> m (DualNumber d r))
   -> (forall out_width' batch_size' block_size' window_size' n_labels'.
-      ( IsScalar d r, KnownNat out_width', KnownNat batch_size'
-      , KnownNat block_size', KnownNat n_labels' )
+      ( IsScalar 'DModeValue r, KnownNat out_width', KnownNat batch_size'
+      , KnownNat block_size', KnownNat window_size', KnownNat n_labels' )
       => Proxy out_width'
       -> SpeechDataBatch batch_size' block_size' window_size' n_labels' r
       -> Domains r
       -> r)
-  -> (forall out_width'. KnownNat out_width'
-      => Proxy out_width' -> (Int, [Int], [(Int, Int)], [OT.ShapeL]))
+  -> (forall out_width' window_size' n_labels'.
+      (KnownNat out_width', KnownNat window_size', KnownNat n_labels')
+      => Proxy out_width' -> Proxy window_size' -> Proxy n_labels'
+      -> (Int, [Int], [(Int, Int)], [OT.ShapeL]))
   -> Float
   -> TestTree
 speechTestCaseRNN prefix epochs maxBatches trainWithLoss ftest flen expected =
-  testCase prefix $
-    1.0 @?= 1.0
+  let proxy_out_width = Proxy @out_width
+      batch_size = valueOf @batch_size
+      ((_, _, _, nParamsX), totalParams, range, parametersInitDouble) =
+        initializerFixed 44 0.2
+          (flen proxy_out_width (Proxy @window_size) (Proxy @n_labels))
+      parametersInit = undefined  -- TODO
+      name = prefix ++ ": "
+             ++ unwords [ show epochs, show maxBatches
+                        , show (valueOf @out_width :: Int), show batch_size
+                        , show nParamsX, show totalParams, show range ]
+  in testCase name $ do
+    hPutStrLn stderr $ printf "\n%s: Epochs to run/max batches per epoch: %d/%d"
+           prefix epochs maxBatches
+    speechDataBatchList <-
+      loadSpeechData
+        @batch_size @block_size @window_size @n_labels
+        "/home/mikolaj/Downloads/volleyball.float32.257.spectrogram.bin"
+        "/home/mikolaj/Downloads/volleyball.float32.1.rms.bin"
+    let trainData = speechDataBatchList
+        testDataBatch = head speechDataBatchList
+        -- There is some visual feedback, because some of these take long.
+        runBatch
+          :: (Domains r, StateAdam r)
+          -> ( Int
+             , [SpeechDataBatch batch_size block_size window_size n_labels r] )
+          -> IO (Domains r, StateAdam r)
+        runBatch (parameters@(!_, !_, !_, !_), stateAdam) (k, batch) = do
+          let f = trainWithLoss proxy_out_width
+              res@(parameters2, _) = sgdAdam f batch parameters stateAdam
+              -- TODO: instead concatenate mini-batches
+              !trainScore = ftest proxy_out_width (head batch) parameters2
+              !testScore = ftest proxy_out_width testDataBatch parameters2
+              !lenBatch = length batch
+          hPutStrLn stderr $ printf "\n%s: (Batch %d with %d points)" prefix k lenBatch
+          hPutStrLn stderr $ printf "%s: Training error:   %.2f%%" prefix ((1 - trainScore) * 100)
+          hPutStrLn stderr $ printf "%s: Validation error: %.2f%%" prefix ((1 - testScore ) * 100)
+          return res
+        runEpoch :: Int -> (Domains r, StateAdam r) -> IO (Domains r)
+        runEpoch n (params2, _) | n > epochs = return params2
+        runEpoch n paramsStateAdam = do
+          hPutStrLn stderr $ printf "\n%s: [Epoch %d]" prefix n
+          let trainDataShuffled = shuffle (mkStdGen $ n + 5) trainData
+              batches = take maxBatches
+                        $ zip [1 ..]
+                        $ chunksOf batch_size trainDataShuffled
+          !res <- foldM runBatch paramsStateAdam batches
+          runEpoch (succ n) res
+    res <- runEpoch 1 (parametersInit, initialStateAdam parametersInit)
+    let testErrorFinal = 1 - ftest proxy_out_width testDataBatch res
+    testErrorFinal @?~ expected
+
 
 mnistRNNTestsLong :: TestTree
 mnistRNNTestsLong = testGroup "Speech RNN long tests"
@@ -159,4 +329,7 @@ speechRNNTestsShort = testGroup "Speech RNN short tests"
       maximum (map (OS.maximumA . fst) speechDataBatchList) @?= 26.52266
       minimum (map (OS.minimumA . snd) speechDataBatchList) @?= 0.0
       maximum (map (OS.maximumA . snd) speechDataBatchList) @?= 1.0
+  , speechTestCaseRNN @128 @32 @20 @257 @1 "1 epoch, 1 batch" 1 1
+                      rnnSpeechLossFused rnnSpeechTest rnnSpeechLen
+                      0.4375
   ]

--- a/test/common/TestSpeechRNN.hs
+++ b/test/common/TestSpeechRNN.hs
@@ -61,7 +61,7 @@ type SpeechDataBatch batch_size block_size window_size n_labels r =
 -- TODO: performance, see https://github.com/schrammc/mnist-idx/blob/master/src/Data/IDX/Internal.hs
 decodeSpeechData
   :: forall batch_size block_size window_size n_labels r.
-     ( Serialize r, Numeric r, Fractional r
+     ( Ord r, Serialize r, Numeric r
      , KnownNat batch_size, KnownNat block_size, KnownNat window_size
      , KnownNat n_labels )
   => LBS.ByteString -> LBS.ByteString
@@ -92,14 +92,13 @@ decodeSpeechData soundsBs labelsBs =
         let labelsBlockSize = valueOf @block_size * valueOf @n_labels
             labelsBlocks = chunksOf labelsBlockSize labelsCh
             -- Tmp hack that only makes sense for n_labels == 1.
-            avgLabels ch = sum ch / fromIntegral (length ch)
-            labelsAvg = map avgLabels labelsBlocks
+            labelsAvg = map maximum labelsBlocks
         in (OS.fromList soundsCh, OS.fromList labelsAvg)
   in zipWith makeSpeechDataBatch soundsChunks labelsChunks
 
 loadSpeechData
   :: forall batch_size block_size window_size n_labels r.
-     ( Serialize r, Numeric r, Fractional r
+     ( Ord r, Serialize r, Numeric r
      , KnownNat batch_size, KnownNat block_size, KnownNat window_size
      , KnownNat n_labels )
   => FilePath -> FilePath

--- a/test/common/TestSpeechRNN.hs
+++ b/test/common/TestSpeechRNN.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE AllowAmbiguousTypes, DataKinds, RankNTypes, TypeFamilies,
+             TypeOperators #-}
+{-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}
+{-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise #-}
+module TestSpeechRNN (testTrees, shortTestForCITrees) where
+
+import Prelude
+
+import           Control.Monad (foldM)
+import qualified Data.Array.DynamicS as OT
+import           Data.Array.Internal (valueOf)
+import qualified Data.Array.ShapedS as OS
+import           Data.List (foldl', unfoldr)
+import           Data.Proxy (Proxy (Proxy))
+import qualified Data.Vector.Generic as V
+import           GHC.TypeLits (KnownNat)
+import           Numeric.LinearAlgebra (Matrix, Vector)
+import qualified Numeric.LinearAlgebra as HM
+import           System.IO (hPutStrLn, stderr)
+import           System.Random
+import           Test.Tasty
+import           Test.Tasty.HUnit hiding (assert)
+import           Text.Printf
+
+-- until stylish-haskell accepts NoStarIsType
+import qualified GHC.TypeLits
+
+import HordeAd
+
+testTrees :: [TestTree]
+testTrees = [ mnistRNNTestsLong
+            , speechRNNTestsShort
+            ]
+
+shortTestForCITrees :: [TestTree]
+shortTestForCITrees = [ speechRNNTestsShort
+                      ]
+
+
+type SpeechDataBatchS batch_size window_size n_labels r =
+  ( OS.Array '[batch_size, window_size] r
+  , OS.Array '[batch_size, n_labels] r )
+
+speechTestCaseRNNS
+  :: forall out_width batch_size window_size n_labels d r m.
+     ( KnownNat out_width, KnownNat batch_size, KnownNat window_size
+     , r ~ Double, d ~ 'DModeGradient, m ~ DualMonadGradient Double )
+  => String
+  -> Int
+  -> Int
+  -> (forall out_width' batch_size' window_size' n_labels'.
+      (DualMonad d r m, KnownNat out_width', KnownNat batch_size')
+      => Proxy out_width'
+      -> SpeechDataBatchS batch_size' window_size' n_labels' r
+      -> DualNumberVariables d r
+      -> m (DualNumber d r))
+  -> (forall out_width' batch_size' window_size' n_labels'.
+      (IsScalar d r, KnownNat out_width', KnownNat batch_size')
+      => Proxy out_width'
+      -> SpeechDataBatchS batch_size' window_size' n_labels' r
+      -> Domains r
+      -> r)
+  -> (forall out_width'. KnownNat out_width'
+      => Proxy out_width' -> (Int, [Int], [(Int, Int)], [OT.ShapeL]))
+  -> Double
+  -> TestTree
+speechTestCaseRNNS prefix epochs maxBatches trainWithLoss ftest flen expected =
+  testCase prefix $
+    1.0 @?= 1.0
+
+mnistRNNTestsLong :: TestTree
+mnistRNNTestsLong = testGroup "Speech RNN long tests"
+  []
+
+speechRNNTestsShort :: TestTree
+speechRNNTestsShort = testGroup "Speech RNN short tests"
+  []

--- a/test/common/TestSpeechRNN.hs
+++ b/test/common/TestSpeechRNN.hs
@@ -71,7 +71,7 @@ decodeSpeechData soundsBs labelsBs =
   let soundsChunkSize =
         valueOf @batch_size * valueOf @block_size * valueOf @window_size
       labelsChunkSize =
-        valueOf @batch_size * valueOf @block_size  -- * valueOf @n_labels
+        valueOf @batch_size * valueOf @block_size  --  * valueOf @n_labels
       !_A1 = assert
                (fromIntegral (LBS.length soundsBs - 8) * labelsChunkSize
                 == fromIntegral (LBS.length labelsBs - 8) * soundsChunkSize) ()
@@ -90,7 +90,7 @@ decodeSpeechData soundsBs labelsBs =
         :: [r] -> [r]
         -> SpeechDataBatch batch_size block_size window_size n_labels r
       makeSpeechDataBatch soundsCh labelsCh =
-        let labelsBlockSize = valueOf @block_size  -- * valueOf @n_labels
+        let labelsBlockSize = valueOf @block_size  --  * valueOf @n_labels
             labelsBlocks = chunksOf labelsBlockSize labelsCh
             -- Tmp hack for files that only have one label.
             f block = let prefix = if maximum block > 0 then [0, 1] else [1, 0]

--- a/test/common/TestSpeechRNN.hs
+++ b/test/common/TestSpeechRNN.hs
@@ -265,7 +265,7 @@ speechTestCaseRNN prefix epochs maxBatches trainWithLoss ftest flen expected =
       ((_, _, _, nParamsX), totalParams, range, parametersInitDouble) =
         initializerFixed 44 0.2
           (flen proxy_out_width (Proxy @window_size) (Proxy @n_labels))
-      parametersInit = undefined  -- TODO
+      parametersInit = mapDomains (HM.cmap realToFrac) parametersInitDouble
       name = prefix ++ ": "
              ++ unwords [ show epochs, show maxBatches
                         , show (valueOf @out_width :: Int), show batch_size

--- a/test/common/TestSpeechRNN.hs
+++ b/test/common/TestSpeechRNN.hs
@@ -14,12 +14,11 @@ import qualified Data.Array.Shape
 import qualified Data.Array.Shaped as OSB
 import qualified Data.Array.ShapedS as OS
 import qualified Data.ByteString.Lazy as LBS
-import           Data.List (foldl', unfoldr)
 import           Data.Proxy (Proxy (Proxy))
-import           Data.Serialize
+import           Data.Serialize (Serialize, decodeLazy)
 import qualified Data.Vector.Generic as V
 import           GHC.TypeLits (KnownNat)
-import           Numeric.LinearAlgebra (Matrix, Numeric, Vector)
+import           Numeric.LinearAlgebra (Numeric, Vector)
 import qualified Numeric.LinearAlgebra as HM
 import           System.IO
   (IOMode (ReadMode), hPutStrLn, stderr, withBinaryFile)
@@ -209,7 +208,7 @@ rnnSpeechLossFused _ (sounds, labels) variables = do
             $ sumElements0 vec
 
 rnnSpeechTest
-  :: forall out_width batch_size block_size window_size n_labels d r m.
+  :: forall out_width batch_size block_size window_size n_labels r.
      ( IsScalar 'DModeValue r, KnownNat out_width, KnownNat batch_size
      , KnownNat block_size, KnownNat window_size, KnownNat n_labels )
   => Proxy out_width

--- a/test/common/TestSpeechRNN.hs
+++ b/test/common/TestSpeechRNN.hs
@@ -175,7 +175,7 @@ rnnSpeech
   :: forall out_width batch_size block_size window_size n_labels d r m.
      ( DualMonad d r m, KnownNat out_width, KnownNat batch_size
      , KnownNat block_size, KnownNat window_size, KnownNat n_labels )
-  => OS.Array '[window_size, block_size, batch_size] r
+  => OS.Array '[block_size, window_size, batch_size] r
   -> DualNumberVariables d r
   -> m (DualNumber d (OS.Array '[n_labels, batch_size] r))
 rnnSpeech xs variables = do
@@ -199,7 +199,7 @@ rnnSpeechLossFused
   -> DualNumberVariables d r
   -> m (DualNumber d r)
 rnnSpeechLossFused _ (sounds, labels) variables = do
-  let xs = OS.transpose @'[2, 1, 0] sounds
+  let xs = OS.transpose @'[1, 2, 0] sounds
   result <- rnnSpeech @out_width @batch_size @block_size @window_size @n_labels
                       xs variables
   let targets2 = HM.tr $ HM.reshape (valueOf @n_labels)
@@ -217,7 +217,7 @@ rnnSpeechTest
   -> Domains r
   -> r
 rnnSpeechTest _ (sounds, labels) parameters =
-  let xs = OS.transpose @'[2, 1, 0] sounds
+  let xs = OS.transpose @'[1, 2, 0] sounds
       outputS =
         primalValue
            (rnnSpeech @out_width @batch_size @block_size @window_size @n_labels
@@ -332,5 +332,5 @@ speechRNNTestsShort = testGroup "Speech RNN short tests"
       maximum (map (OS.maximumA . snd) speechDataBatchList) @?= 1.0
   , speechTestCaseRNN @128 @32 @20 @257 @1 "1 epoch, 1 batch" 1 1
                       rnnSpeechLossFused rnnSpeechTest rnnSpeechLen
-                      0.4375
+                      0
   ]

--- a/test/common/TestSpeechRNN.hs
+++ b/test/common/TestSpeechRNN.hs
@@ -187,7 +187,8 @@ rnnSpeech xs variables = do
       b2 = varS variables 5
       w3 = varS variables 6
       b3 = varS variables 7
-  rnnSpeechZero @out_width xs ((wX, wS, b), (wX2, wS2, b2)) w3 b3
+  rnnSpeechZero @out_width @batch_size @block_size
+                xs ((wX, wS, b), (wX2, wS2, b2)) w3 b3
 
 rnnSpeechLossFused
   :: forall out_width batch_size block_size window_size n_labels d r m.

--- a/test/common/TestSpeechRNN.hs
+++ b/test/common/TestSpeechRNN.hs
@@ -145,4 +145,8 @@ speechRNNTestsShort = testGroup "Speech RNN short tests"
           "/home/mikolaj/Downloads/volleyball.float32.257.spectrogram.bin"
           "/home/mikolaj/Downloads/volleyball.float32.1.rms.bin"
       length speechDataBatchList @?= 859 `div` 64
+      minimum (map (OS.minimumA . fst) speechDataBatchList) @?= 0.0
+      maximum (map (OS.maximumA . fst) speechDataBatchList) @?= 26.52266
+      minimum (map (OS.minimumA . snd) speechDataBatchList) @?= 0.0
+      maximum (map (OS.maximumA . snd) speechDataBatchList) @?= 1.0
   ]


### PR DESCRIPTION
Implements #58. An attempt to recognize to which person a voice belongs in a given window of a sound file. Uses RNN. 

The tests to run are `cabal test extremelyLongTest --enable-optimization -f test_seq --test-options='-p "Speech RNN"''`. Example data files not yet included.