### PR TITLE
pretty-print HUnitFailure exceptions

### DIFF
--- a/horde-ad.cabal
+++ b/horde-ad.cabal
@@ -209,7 +209,6 @@ library testLibrary
     build-depends:
         base
       , deepseq
-      , HUnit-approx
       , hmatrix
       , horde-ad
       , ilist

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -40,10 +40,10 @@ exceptionHandler :: SomeException -> IO ()
 exceptionHandler (SomeException e) = do
   case e of
     -- The wildcard branch below prints:
-    -- Hello from exceptionHandler! (1) Exception is: HUnitFailure (Just (SrcLoc {srcLocPackage = "horde-ad-0.1.0.0-inplace-testLibrary", srcLocModule = "TestCommonEqEpsilon", srcLocFile = "test/common/TestCommonEqEpsilon.hs", srcLocStartLine = 122, srcLocStartCol = 5, srcLocEndLine = 122, srcLocEndCol = 16})) (Reason "expected: 0.8991\n but got: 0.7424999999999999\n (maximum margin of error: 1.0e-6)") of type: HUnitFailure
+    -- Hello from exceptionHandler! Exception is: HUnitFailure (Just (SrcLoc {srcLocPackage = "horde-ad-0.1.0.0-inplace-testLibrary", srcLocModule = "TestCommonEqEpsilon", srcLocFile = "test/common/TestCommonEqEpsilon.hs", srcLocStartLine = 118, srcLocStartCol = 5, srcLocEndLine = 118, srcLocEndCol = 16})) (Reason "expected: 0.8991\n but got: 0.7424999999999999\n (maximum margin of error: 1.0e-6)") of type: HUnitFailure
     -- BUT we cannot match e with HUnitFailure x y because it doesn't compile:
     -- HUnitFailure x y -> putStrLn $ "We got HUnitFailure!"
-    _ -> putStrLn $ "Hello from exceptionHandler! (1) Exception is: " ++ (show e) ++ " of type: " ++ (show $ typeOf e)
+    _ -> putStrLn $ "Hello from exceptionHandler! Exception is: " ++ (show e) ++ " of type: " ++ (show $ typeOf e)
 
 -- | Asserts that the specified actual floating point value is close to the expected value.
 -- The output message will contain the prefix, the expected value, and the

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -17,6 +17,8 @@ import           Test.Tasty.Options
 -- because we do not want to depend on Test.HUnit.Approx . Instead, we're using an outdated copy of HUnit hardcoded into
 -- Tasty (Test.Tasty.HUnit).
 --
+-- TODO: remove assertApproxEqual once it is available in Tasty
+--
 -- Asserts that the specified actual value is approximately equal to the
 -- expected value. The output message will contain the prefix, the expected
 -- value, the actual value, and the maximum margin of error.

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -36,8 +36,10 @@ eqEpsilonRef = unsafePerformIO $ newIORef eqEpsilonDefault
 setEpsilonEq :: EqEpsilon -> IO ()
 setEpsilonEq (EqEpsilon x) = atomicWriteIORef eqEpsilonRef x
 
-exceptionHandler :: HUnitFailure -> IO ()
-exceptionHandler e = putStrLn $ "Hello from exceptionHandler! We got HUnitFailure: " ++ show e
+exceptionHandler :: SomeException -> IO ()
+exceptionHandler e = do
+  putStrLn $ "Hello from exceptionHandler! We got HUnitFailure: " ++ show e
+  throwIO e
 
 -- | Asserts that the specified actual floating point value is close to the expected value.
 -- The output message will contain the prefix, the expected value, and the

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -5,7 +5,6 @@ module TestCommonEqEpsilon (EqEpsilon, setEpsilonEq, assertCloseElem, (@?~)) whe
 import Prelude
 import Data.Typeable
 
-import           Control.Exception
 import           Control.Monad (unless)
 import           Data.IORef
 import qualified Data.Vector.Generic as VG

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -17,6 +17,9 @@ import           Test.Tasty.Options
 -- because we do not want to depend on Test.HUnit.Approx . Instead, we're using an outdated copy of HUnit hardcoded into
 -- Tasty (Test.Tasty.HUnit).
 --
+-- Copyright (c) 2014, Richard Eisenberg
+-- All rights reserved.
+--
 -- TODO: remove assertApproxEqual once it is available in Tasty
 --
 -- Asserts that the specified actual value is approximately equal to the

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -5,6 +5,7 @@ module TestCommonEqEpsilon (EqEpsilon, setEpsilonEq, assertCloseElem, (@?~)) whe
 import Prelude
 import Data.Typeable
 
+import           Control.Exception
 import           Data.IORef
 import qualified Data.Vector.Generic as VG
 import qualified Data.Vector.Storable as VS
@@ -35,6 +36,9 @@ eqEpsilonRef = unsafePerformIO $ newIORef eqEpsilonDefault
 setEpsilonEq :: EqEpsilon -> IO ()
 setEpsilonEq (EqEpsilon x) = atomicWriteIORef eqEpsilonRef x
 
+exceptionHandler :: HUnitFailure -> IO ()
+exceptionHandler e = putStrLn $ "Hello from exceptionHandler! We got HUnitFailure: " ++ show e
+
 -- | Asserts that the specified actual floating point value is close to the expected value.
 -- The output message will contain the prefix, the expected value, and the
 -- actual value.
@@ -47,8 +51,12 @@ assertClose :: forall a. (Fractional a, Ord a, Show a, HasCallStack)
             -> a      -- ^ The actual value
             -> Assertion
 assertClose preface expected actual = do
+  putStrLn "DEBUG-XXX-0"
   eqEpsilon <- readIORef eqEpsilonRef
-  Test.HUnit.Approx.assertApproxEqual preface (fromRational eqEpsilon) expected actual
+  putStrLn "DEBUG-XXX-1"
+  putStrLn "DEBUG-XXX-2"
+  catch (Test.HUnit.Approx.assertApproxEqual preface (fromRational eqEpsilon) expected actual) exceptionHandler
+  putStrLn "DEBUG-XXX-3"
 
 -- | Asserts that the specified actual floating point value is close to at least one of the expected values.
 assertCloseElem :: forall a. (Fractional a, Ord a, Show a, HasCallStack)

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -58,15 +58,6 @@ eqEpsilonRef = unsafePerformIO $ newIORef eqEpsilonDefault
 setEpsilonEq :: EqEpsilon -> IO ()
 setEpsilonEq (EqEpsilon x) = atomicWriteIORef eqEpsilonRef x
 
---exceptionHandler :: SomeException -> IO ()
---exceptionHandler (SomeException e) = do
---  case e of
---    -- The wildcard branch below prints:
---    -- Hello from exceptionHandler! Exception is: HUnitFailure (Just (SrcLoc {srcLocPackage = "horde-ad-0.1.0.0-inplace-testLibrary", srcLocModule = "TestCommonEqEpsilon", srcLocFile = "test/common/TestCommonEqEpsilon.hs", srcLocStartLine = 118, srcLocStartCol = 5, srcLocEndLine = 118, srcLocEndCol = 16})) (Reason "expected: 0.8991\n but got: 0.7424999999999999\n (maximum margin of error: 1.0e-6)") of type: HUnitFailure
---    -- BUT we cannot match e with HUnitFailure x y because it doesn't compile:
---    HUnitFailure x y -> putStrLn $ "We got HUnitFailure!"
---    _ -> putStrLn $ "Hello from exceptionHandler! Exception is: " ++ (show e) ++ " of type: " ++ (show $ typeOf e)
-
 -- | Asserts that the specified actual floating point value is close to the expected value.
 -- The output message will contain the prefix, the expected value, and the
 -- actual value.

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -37,9 +37,13 @@ setEpsilonEq :: EqEpsilon -> IO ()
 setEpsilonEq (EqEpsilon x) = atomicWriteIORef eqEpsilonRef x
 
 exceptionHandler :: SomeException -> IO ()
-exceptionHandler e = do
-  putStrLn $ "Hello from exceptionHandler! We got HUnitFailure: " ++ show e
-  throwIO e
+exceptionHandler (SomeException e) = do
+  case e of
+    -- The wildcard branch below prints:
+    -- Hello from exceptionHandler! (1) Exception is: HUnitFailure (Just (SrcLoc {srcLocPackage = "horde-ad-0.1.0.0-inplace-testLibrary", srcLocModule = "TestCommonEqEpsilon", srcLocFile = "test/common/TestCommonEqEpsilon.hs", srcLocStartLine = 122, srcLocStartCol = 5, srcLocEndLine = 122, srcLocEndCol = 16})) (Reason "expected: 0.8991\n but got: 0.7424999999999999\n (maximum margin of error: 1.0e-6)") of type: HUnitFailure
+    -- BUT we cannot match e with HUnitFailure x y because it doesn't compile:
+    -- HUnitFailure x y -> putStrLn $ "We got HUnitFailure!"
+    _ -> putStrLn $ "Hello from exceptionHandler! (1) Exception is: " ++ (show e) ++ " of type: " ++ (show $ typeOf e)
 
 -- | Asserts that the specified actual floating point value is close to the expected value.
 -- The output message will contain the prefix, the expected value, and the


### PR DESCRIPTION
Implements pretty printing of `HUnitFailure` exceptions by removing the dependency on `HUnit-approx`.

Fixes #60 