### PR TITLE
implement equality testing with explicit error margin

### DIFF
--- a/horde-ad.cabal
+++ b/horde-ad.cabal
@@ -216,6 +216,7 @@ library testLibrary
     -- Other library packages from which modules are imported.
     build-depends:
         base
+      , Cabal
       , deepseq
       , hmatrix
       , horde-ad

--- a/horde-ad.cabal
+++ b/horde-ad.cabal
@@ -216,7 +216,6 @@ library testLibrary
     -- Other library packages from which modules are imported.
     build-depends:
         base
-      , Cabal
       , deepseq
       , hmatrix
       , horde-ad

--- a/test/common/TestCommon.hs
+++ b/test/common/TestCommon.hs
@@ -192,5 +192,5 @@ instance (VS.Storable a) => Linearizable (OT.Array a) a where
 instance (VS.Storable a, OS.Shape sh) => Linearizable (OS.Array sh a) a where
   linearize = OS.toList
 
-instance {-# OVERLAPPABLE #-} (Foldable t) => Linearizable (t a) a where
-  linearize = foldr (:) []
+instance (VS.Storable a, HM.Element a) => Linearizable (HM.Matrix a) a where
+  linearize = HM.toList . HM.flatten

--- a/test/common/TestCommon.hs
+++ b/test/common/TestCommon.hs
@@ -192,5 +192,5 @@ instance (VS.Storable a) => Linearizable (OT.Array a) a where
 instance (VS.Storable a, OS.Shape sh) => Linearizable (OS.Array sh a) a where
   linearize = OS.toList
 
-instance (VS.Storable a, HM.Element a) => Linearizable (HM.Matrix a) a where
-  linearize = HM.toList . HM.flatten
+instance {-# OVERLAPPABLE #-} (Foldable t) => Linearizable (t a) a where
+  linearize = foldr (:) []

--- a/test/common/TestCommon.hs
+++ b/test/common/TestCommon.hs
@@ -10,6 +10,7 @@ import Prelude
 
 import qualified Data.Array.DynamicS as OT
 import qualified Data.Array.ShapedS as OS
+import qualified Data.Foldable
 import qualified Data.Vector.Generic as V
 import qualified Data.Vector.Storable as VS
 import qualified Numeric.LinearAlgebra as HM
@@ -199,4 +200,4 @@ instance (VS.Storable a, HM.Element a) => Linearizable (HM.Matrix a) a where
   linearize = HM.toList . HM.flatten
 
 instance {-# OVERLAPPABLE #-} (Foldable t) => Linearizable (t a) a where
-  linearize = foldr (:) []
+  linearize = Data.Foldable.toList

--- a/test/common/TestCommon.hs
+++ b/test/common/TestCommon.hs
@@ -166,7 +166,7 @@ class HasShape a where
   shapeL :: a -> ShapeL
 
 instance (VS.Storable a) => HasShape (VS.Vector a) where
-  shapeL vec = [VS.length vec]
+  shapeL = (: []) . VS.length
 
 instance HasShape (OT.Array a) where
   shapeL = OT.shapeL
@@ -175,7 +175,7 @@ instance HasShape (HM.Matrix a) where
   shapeL matrix = [HM.rows matrix, HM.cols matrix]
 
 instance {-# OVERLAPPABLE #-} (Foldable t) => HasShape (t a) where
-  shapeL = (.) (flip (:) []) length
+  shapeL = (: []) . length
 
 ----------------------------------------------------------------------------
 -- Things that can be linearized, i.e. converted to a list

--- a/test/common/TestCommon.hs
+++ b/test/common/TestCommon.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE DataKinds, FlexibleInstances, FunctionalDependencies, RankNTypes, TypeFamilies #-}
-module TestCommon (listsToParameters,
+module TestCommon (lowercase, listsToParameters,
                    cmpTwo, cmpTwoSimple,
                    qcPropDom, quickCheckTest0, fquad, quad,
                    HasShape (shapeL),
@@ -10,6 +10,7 @@ import Prelude
 
 import qualified Data.Array.DynamicS as OT
 import qualified Data.Array.ShapedS as OS
+import qualified Data.Char
 import qualified Data.Foldable
 import qualified Data.Vector.Generic as V
 import qualified Data.Vector.Storable as VS
@@ -19,6 +20,9 @@ import           Test.Tasty.QuickCheck
 
 import HordeAd hiding (sumElementsVectorOfDual)
 import HordeAd.Core.DualClass (Dual)
+
+lowercase :: String -> String
+lowercase = map Data.Char.toLower
 
 -- Checks if 2 numbers are close enough.
 close1 :: forall r. (Ord r, Fractional r)

--- a/test/common/TestCommon.hs
+++ b/test/common/TestCommon.hs
@@ -171,9 +171,6 @@ instance (VS.Storable a) => HasShape (VS.Vector a) where
 instance HasShape (OT.Array a) where
   shapeL = OT.shapeL
 
-instance (OS.Shape sh) => HasShape (OS.Array sh a) where
-  shapeL = OS.shapeL
-
 instance HasShape (HM.Matrix a) where
   shapeL matrix = [HM.rows matrix, HM.cols matrix]
 

--- a/test/common/TestCommon.hs
+++ b/test/common/TestCommon.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DataKinds, FlexibleInstances, FunctionalDependencies, MultiParamTypeClasses, RankNTypes, TypeFamilies #-}
+{-# LANGUAGE DataKinds, FlexibleInstances, FunctionalDependencies, RankNTypes, TypeFamilies #-}
 module TestCommon (listsToParameters,
                    cmpTwo, cmpTwoSimple,
                    qcPropDom, quickCheckTest0, fquad, quad,

--- a/test/common/TestCommon.hs
+++ b/test/common/TestCommon.hs
@@ -2,8 +2,8 @@
 module TestCommon (listsToParameters,
                    cmpTwo, cmpTwoSimple,
                    qcPropDom, quickCheckTest0, fquad, quad,
-                   HasShape, shapeL,
-                   Linearizable, linearize
+                   HasShape (shapeL),
+                   Linearizable (linearize)
                   ) where
 
 import Prelude

--- a/test/common/TestCommon.hs
+++ b/test/common/TestCommon.hs
@@ -176,6 +176,9 @@ instance (OS.Shape sh) => HasShape (OS.Array sh a) where
 instance HasShape (HM.Matrix a) where
   shapeL matrix = [HM.rows matrix, HM.cols matrix]
 
+instance {-# OVERLAPPABLE #-} (Foldable t) => HasShape (t a) where
+  shapeL = (.) (flip (:) []) length
+
 ----------------------------------------------------------------------------
 -- Things that can be linearized, i.e. converted to a list
 ----------------------------------------------------------------------------
@@ -194,3 +197,6 @@ instance (VS.Storable a, OS.Shape sh) => Linearizable (OS.Array sh a) a where
 
 instance (VS.Storable a, HM.Element a) => Linearizable (HM.Matrix a) a where
   linearize = HM.toList . HM.flatten
+
+instance {-# OVERLAPPABLE #-} (Foldable t) => Linearizable (t a) a where
+  linearize = foldr (:) []

--- a/test/common/TestCommon.hs
+++ b/test/common/TestCommon.hs
@@ -164,6 +164,9 @@ type ShapeL = [Int]
 class HasShape a where
   shapeL :: a -> ShapeL
 
+instance (VS.Storable a) => HasShape (VS.Vector a) where
+  shapeL vec = [VS.length vec]
+
 instance HasShape (OT.Array a) where
   shapeL = OT.shapeL
 
@@ -179,6 +182,9 @@ instance HasShape (HM.Matrix a) where
 
 class Linearizable a b | a -> b where
   linearize :: a -> [b]
+
+instance (VS.Storable a) => Linearizable (VS.Vector a) a where
+  linearize = VS.toList
 
 instance (VS.Storable a) => Linearizable (OT.Array a) a where
   linearize = OT.toList

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -185,16 +185,10 @@ assertCloseElem preface expected actual = do
     go_assert eqEps (h:t) =
       if abs (h-actual) < fromRational eqEps then assertEqualUpToEps msg (fromRational eqEps) h actual else go_assert eqEps t
 
-assert_close :: (AssertEqualUpToEpsilon z a)
-      => a -- ^ The expected value
-      -> a -- ^ The actual value
-      -> Assertion
-assert_close expected actual = do
-  eqEpsilon <- readIORef eqEpsilonRef
-  assertEqualUpToEpsilon (fromRational eqEpsilon) expected actual
-
 (@?~) :: (AssertEqualUpToEpsilon z a)
       => a -- ^ The actual value
       -> a -- ^ The expected value
       -> Assertion
-(@?~) = flip assert_close
+(@?~) actual expected = do
+  eqEpsilon <- readIORef eqEpsilonRef
+  assertEqualUpToEpsilon (fromRational eqEpsilon) expected actual

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -115,34 +115,34 @@ class (Fractional z) => AssertEqualUpToEpsilon z a | a -> z where
                          -> a -- ^ The actual value
                          -> Assertion
 
-instance {-# OVERLAPPABLE #-} AssertEqualUpToEpsilon Double Double where
+instance AssertEqualUpToEpsilon Double Double where
   assertEqualUpToEpsilon :: Double -> Double -> Double -> Assertion
   assertEqualUpToEpsilon = assert_close_eps ""
 
-instance {-# OVERLAPPABLE #-} AssertEqualUpToEpsilon Float Float where
+instance AssertEqualUpToEpsilon Float Float where
   assertEqualUpToEpsilon :: Float -> Float -> Float -> Assertion
   assertEqualUpToEpsilon = assert_close_eps ""
 
-instance {-# OVERLAPPABLE #-} (AssertEqualUpToEpsilon z a,
-                               AssertEqualUpToEpsilon z b) => AssertEqualUpToEpsilon z (a,b) where
+instance (AssertEqualUpToEpsilon z a,
+          AssertEqualUpToEpsilon z b) => AssertEqualUpToEpsilon z (a,b) where
   assertEqualUpToEpsilon :: z -> (a,b) -> (a,b) -> Assertion
   assertEqualUpToEpsilon eqEpsilon (e1,e2) (a1,a2) =
     assertEqualUpToEpsilon eqEpsilon e1 a1 >>
     assertEqualUpToEpsilon eqEpsilon e2 a2
 
-instance {-# OVERLAPPABLE #-} (AssertEqualUpToEpsilon z a,
-                               AssertEqualUpToEpsilon z b,
-                               AssertEqualUpToEpsilon z c) => AssertEqualUpToEpsilon z (a,b,c) where
+instance (AssertEqualUpToEpsilon z a,
+          AssertEqualUpToEpsilon z b,
+          AssertEqualUpToEpsilon z c) => AssertEqualUpToEpsilon z (a,b,c) where
   assertEqualUpToEpsilon :: z -> (a,b,c) -> (a,b,c) -> Assertion
   assertEqualUpToEpsilon eqEpsilon (e1,e2,e3) (a1,a2,a3) =
     assertEqualUpToEpsilon eqEpsilon e1 a1 >>
     assertEqualUpToEpsilon eqEpsilon e2 a2 >>
     assertEqualUpToEpsilon eqEpsilon e3 a3
 
-instance {-# OVERLAPPABLE #-} (AssertEqualUpToEpsilon z a,
-                               AssertEqualUpToEpsilon z b,
-                               AssertEqualUpToEpsilon z c,
-                               AssertEqualUpToEpsilon z d) => AssertEqualUpToEpsilon z (a,b,c,d) where
+instance (AssertEqualUpToEpsilon z a,
+          AssertEqualUpToEpsilon z b,
+          AssertEqualUpToEpsilon z c,
+          AssertEqualUpToEpsilon z d) => AssertEqualUpToEpsilon z (a,b,c,d) where
   assertEqualUpToEpsilon :: z -> (a,b,c,d) -> (a,b,c,d) -> Assertion
   assertEqualUpToEpsilon eqEpsilon (e1,e2,e3,e4) (a1,a2,a3,a4) =
     assertEqualUpToEpsilon eqEpsilon e1 a1 >>
@@ -150,17 +150,17 @@ instance {-# OVERLAPPABLE #-} (AssertEqualUpToEpsilon z a,
     assertEqualUpToEpsilon eqEpsilon e3 a3 >>
     assertEqualUpToEpsilon eqEpsilon e4 a4
 
-instance {-# OVERLAPPABLE #-} (Traversable t, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (t a) where
+instance (Traversable t, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (t a) where
   assertEqualUpToEpsilon :: z -> t a -> t a -> Assertion
   assertEqualUpToEpsilon eqEpsilon expected actual =
     assert_list (assertEqualUpToEpsilon eqEpsilon) (as_list expected) (as_list actual)
 
-instance {-# OVERLAPPABLE #-} (VS.Storable a, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (VS.Vector a) where
+instance (VS.Storable a, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (VS.Vector a) where
   assertEqualUpToEpsilon :: z -> VS.Vector a -> VS.Vector a -> Assertion
   assertEqualUpToEpsilon eqEpsilon expected actual =
     assert_list (assertEqualUpToEpsilon eqEpsilon) (VG.toList expected) (VG.toList actual)
 
-instance {-# OVERLAPPABLE #-} (VS.Storable a, OS.Shape sh1, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (OS.Array sh1 a) where
+instance (VS.Storable a, OS.Shape sh1, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (OS.Array sh1 a) where
   assertEqualUpToEpsilon :: z -> OS.Array sh1 a -> OS.Array sh1 a -> Assertion
   assertEqualUpToEpsilon eqEpsilon = assert_shape (assertEqualUpToEpsilon eqEpsilon)
 

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -10,6 +10,7 @@ import Prelude
 
 import qualified Data.Array.ShapedS as OS
 import           Data.IORef
+import           Distribution.Simple.Utils (lowercase)
 import qualified Data.Vector.Storable as VS
 import           System.IO.Unsafe
 import           Test.Tasty.HUnit
@@ -97,11 +98,13 @@ assert_close_eps :: (Num a, Ord a, Show a, HasCallStack)
                    -> a      -- ^ The actual value
                    -> Assertion
 assert_close_eps preface epilogue eqEpsilon expected actual = do
-  assertBool (msg eqEpsilon) (abs (expected-actual) <= eqEpsilon)
-  where msg errorMargin = (if null preface then "" else preface ++ "\n") ++
-                           "expected: " ++ show expected ++ "\n but got: " ++ show actual ++
-                           "\n (maximum margin of error: " ++ show errorMargin ++ ")" ++
-                           (if null epilogue then "" else "\n" ++ epilogue)
+  assertBool (message eqEpsilon) (abs (expected-actual) <= eqEpsilon)
+  where
+    msg = "expected: " ++ show expected ++ "\n but got: " ++ show actual
+    t = lowercase
+    message errorMargin = (if null preface then "" else preface ++ "\n") ++
+                          msg ++ "\n (maximum margin of error: " ++ show errorMargin ++ ")" ++
+                          (if (null epilogue) || (t epilogue == t preface) || (t epilogue == t msg) then "" else "\n" ++ epilogue)
 
 ----------------------------------------------------------------------------
 -- AssertEqualUpToEpsilon class

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -70,6 +70,20 @@ assert_list make_assert expected actual =
     lenE :: Int = length expected
     lenA :: Int = length actual
 
+assert_shape :: forall a sh. (VS.Storable a, OS.Shape sh)
+            => (a -> a -> Assertion) -- ^ The function used to make an assertion on two elements (expected, actual)
+            -> (OS.Array sh a)       -- ^ The expected value
+            -> (OS.Array sh a)       -- ^ The actual value
+            -> Assertion
+assert_shape make_assert expected actual =
+  if shapeE == shapeA then
+    assert_list make_assert (OS.toList expected) (OS.toList actual)
+  else
+    assertFailure $ "Expected shape: " ++ show shapeE ++ ", but got: " ++ show shapeA
+  where
+    shapeE = OS.shapeL expected
+    shapeA = OS.shapeL actual
+
 -- | Foldable to list.
 asList :: Foldable t => t a -> [a]
 asList = foldr (:) []

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -151,21 +151,20 @@ instance (AssertEqualUpToEpsilon z a,
     assertEqualUpToEpsilon eqEpsilon e3 a3 >>
     assertEqualUpToEpsilon eqEpsilon e4 a4
 
-instance (Traversable t, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (t a) where
+instance {-# OVERLAPPABLE #-} (Traversable t, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (t a) where
   assertEqualUpToEpsilon :: z -> t a -> t a -> Assertion
   assertEqualUpToEpsilon eqEpsilon expected actual =
     assert_list (assertEqualUpToEpsilon eqEpsilon) (as_list expected) (as_list actual)
 
 instance (VS.Storable a, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (VS.Vector a) where
   assertEqualUpToEpsilon :: z -> VS.Vector a -> VS.Vector a -> Assertion
-  assertEqualUpToEpsilon eqEpsilon expected actual =
-    assert_list (assertEqualUpToEpsilon eqEpsilon) (VS.toList expected) (VS.toList actual)
+  assertEqualUpToEpsilon eqEpsilon = assert_shape (assertEqualUpToEpsilon eqEpsilon)
 
 instance (VS.Storable a, OS.Shape sh1, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (OS.Array sh1 a) where
   assertEqualUpToEpsilon :: z -> OS.Array sh1 a -> OS.Array sh1 a -> Assertion
   assertEqualUpToEpsilon eqEpsilon = assert_shape (assertEqualUpToEpsilon eqEpsilon)
 
-instance (Fractional z, HasShape a, Linearizable a b, AssertEqualUpToEpsilon z b) => AssertEqualUpToEpsilon z a where
+instance {-# OVERLAPPABLE #-} (Fractional z, HasShape a, Linearizable a b, AssertEqualUpToEpsilon z b) => AssertEqualUpToEpsilon z a where
   assertEqualUpToEpsilon :: z -> a -> a -> Assertion
   assertEqualUpToEpsilon eqEpsilon = assert_shape (assertEqualUpToEpsilon eqEpsilon)
 

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -168,21 +168,6 @@ instance {-# OVERLAPPABLE #-} (VS.Storable a, OS.Shape sh1, AssertEqualUpToEpsil
 -- Generic comparisons without explicit error margin
 ----------------------------------------------------------------------------
 
--- | Asserts that the specified actual floating point value is close to the expected value.
--- The output message will contain the prefix, the expected value, and the
--- actual value.
---
--- If the prefix is the empty string (i.e., @\"\"@), then the prefix is omitted
--- and only the expected and actual values are output.
-assertClose :: (Fractional a, Ord a, Show a, HasCallStack)
-            => String -- ^ The message prefix
-            -> a      -- ^ The expected value
-            -> a      -- ^ The actual value
-            -> Assertion
-assertClose preface expected actual = do
-  eqEpsilon <- readIORef eqEpsilonRef
-  assertEqualUpToEps preface (fromRational eqEpsilon) expected actual
-
 -- | Asserts that the specified actual floating point value is close to at least one of the expected values.
 assertCloseElem :: forall a. (Fractional a, Ord a, Show a, HasCallStack)
                 => String   -- ^ The message prefix
@@ -198,7 +183,7 @@ assertCloseElem preface expected actual = do
     go_assert :: Rational -> [a] -> Assertion
     go_assert _ [] = assertFailure msg
     go_assert eqEps (h:t) =
-      if abs (h-actual) < fromRational eqEps then assertClose msg h actual else go_assert eqEps t
+      if abs (h-actual) < fromRational eqEps then assertEqualUpToEps msg (fromRational eqEps) h actual else go_assert eqEps t
 
 assert_close :: (AssertEqualUpToEpsilon z a)
       => a -- ^ The expected value

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -69,10 +69,10 @@ assert_list make_assert expected actual =
     lenA :: Int = length actual
 
 assert_shape :: forall a sh. (VS.Storable a, OS.Shape sh)
-            => (a -> a -> Assertion) -- ^ The function used to make an assertion on two elements (expected, actual)
-            -> (OS.Array sh a)       -- ^ The expected value
-            -> (OS.Array sh a)       -- ^ The actual value
-            -> Assertion
+             => (a -> a -> Assertion) -- ^ The function used to make an assertion on two elements (expected, actual)
+             -> (OS.Array sh a)       -- ^ The expected value
+             -> (OS.Array sh a)       -- ^ The actual value
+             -> Assertion
 assert_shape make_assert expected actual =
   if shapeE == shapeA then
     assert_list make_assert (OS.toList expected) (OS.toList actual)

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -151,7 +151,7 @@ instance (AssertEqualUpToEpsilon z a,
     assertEqualUpToEpsilon eqEpsilon e3 a3 >>
     assertEqualUpToEpsilon eqEpsilon e4 a4
 
-instance {-# OVERLAPPABLE #-} (Traversable t, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (t a) where
+instance {-# OVERLAPPABLE #-} (Foldable t, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (t a) where
   assertEqualUpToEpsilon :: z -> t a -> t a -> Assertion
   assertEqualUpToEpsilon eqEpsilon expected actual =
     assert_list (assertEqualUpToEpsilon eqEpsilon) (as_list expected) (as_list actual)

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -151,20 +151,11 @@ instance (AssertEqualUpToEpsilon z a,
     assertEqualUpToEpsilon eqEpsilon e3 a3 >>
     assertEqualUpToEpsilon eqEpsilon e4 a4
 
-instance {-# OVERLAPPABLE #-} (Foldable t, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (t a) where
-  assertEqualUpToEpsilon :: z -> t a -> t a -> Assertion
-  assertEqualUpToEpsilon eqEpsilon expected actual =
-    assert_list (assertEqualUpToEpsilon eqEpsilon) (as_list expected) (as_list actual)
-
-instance (VS.Storable a, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (VS.Vector a) where
-  assertEqualUpToEpsilon :: z -> VS.Vector a -> VS.Vector a -> Assertion
-  assertEqualUpToEpsilon eqEpsilon = assert_shape (assertEqualUpToEpsilon eqEpsilon)
-
 instance (VS.Storable a, OS.Shape sh1, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (OS.Array sh1 a) where
   assertEqualUpToEpsilon :: z -> OS.Array sh1 a -> OS.Array sh1 a -> Assertion
   assertEqualUpToEpsilon eqEpsilon = assert_shape (assertEqualUpToEpsilon eqEpsilon)
 
-instance {-# OVERLAPPABLE #-} (Fractional z, HasShape a, Linearizable a b, AssertEqualUpToEpsilon z b) => AssertEqualUpToEpsilon z a where
+instance (Fractional z, HasShape a, Linearizable a b, AssertEqualUpToEpsilon z b) => AssertEqualUpToEpsilon z a where
   assertEqualUpToEpsilon :: z -> a -> a -> Assertion
   assertEqualUpToEpsilon eqEpsilon = assert_shape (assertEqualUpToEpsilon eqEpsilon)
 

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -152,6 +152,15 @@ instance {-# OVERLAPPABLE #-} (AssertEqualUpToEpsilon z a,
     assertEqualUpToEpsilon eqEpsilon e1 a1 >>
     assertEqualUpToEpsilon eqEpsilon e2 a2
 
+instance {-# OVERLAPPABLE #-} (AssertEqualUpToEpsilon z a,
+                               AssertEqualUpToEpsilon z b,
+                               AssertEqualUpToEpsilon z c) => AssertEqualUpToEpsilon z (a,b,c) where
+  assertEqualUpToEpsilon :: z -> (a,b,c) -> (a,b,c) -> Assertion
+  assertEqualUpToEpsilon eqEpsilon (e1,e2,e3) (a1,a2,a3) =
+    assertEqualUpToEpsilon eqEpsilon e1 a1 >>
+    assertEqualUpToEpsilon eqEpsilon e2 a2 >>
+    assertEqualUpToEpsilon eqEpsilon e3 a3
+
 ----------------------------------------------------------------------------
 -- Generic comparisons without explicit error margin
 ----------------------------------------------------------------------------

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -150,7 +150,7 @@ instance (AssertEqualUpToEpsilon z a,
     assertEqualUpToEpsilon eqEpsilon e3 a3 >>
     assertEqualUpToEpsilon eqEpsilon e4 a4
 
-instance (Traversable t, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (t a) where
+instance {-# OVERLAPPABLE #-} (Traversable t, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (t a) where
   assertEqualUpToEpsilon :: z -> t a -> t a -> Assertion
   assertEqualUpToEpsilon eqEpsilon expected actual =
     assert_list (assertEqualUpToEpsilon eqEpsilon) (as_list expected) (as_list actual)

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -160,7 +160,7 @@ instance (AssertEqualUpToEpsilon z a,
 
 instance (VS.Storable a, OS.Shape sh1, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (OS.Array sh1 a) where
   assertEqualUpToEpsilonWithMsg :: String -> z -> OS.Array sh1 a -> OS.Array sh1 a -> Assertion
-  assertEqualUpToEpsilonWithMsg msg eqEpsilon = assert_shape (assertEqualUpToEpsilonWithMsg msg eqEpsilon)
+  assertEqualUpToEpsilonWithMsg msg eqEpsilon expected actual = assert_list (assertEqualUpToEpsilonWithMsg msg eqEpsilon) (linearize expected) (linearize actual)
 
 instance {-# OVERLAPPABLE #-} (Fractional z, Show a, HasShape a, Linearizable a b, AssertEqualUpToEpsilon z b) => AssertEqualUpToEpsilon z a where
   assertEqualUpToEpsilonWithMsg :: String -> z -> a -> a -> Assertion

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -92,7 +92,7 @@ asList = foldr (:) []
 --
 -- If the prefix is the empty string (i.e., @\"\"@), then the prefix is omitted
 -- and only the expected and actual values are output.
-assertEqualUpToEps :: (Fractional a, Ord a, Show a, HasCallStack)
+assertEqualUpToEps :: (Num a, Ord a, Show a, HasCallStack)
                    => String -- ^ The message prefix
                    -> a      -- ^ The error margin
                    -> a      -- ^ The expected value

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -41,8 +41,7 @@ setEpsilonEq (EqEpsilon x) = atomicWriteIORef eqEpsilonRef x
 -- Helper functions
 ----------------------------------------------------------------------------
 
-go_assert_list :: forall a. ()
-               => (a -> a -> Assertion) -- ^ The function used to make an assertion on two elements (expected, actual)
+go_assert_list :: (a -> a -> Assertion) -- ^ The function used to make an assertion on two elements (expected, actual)
                -> [a]                   -- ^ The expected value
                -> [a]                   -- ^ The actual value
                -> Assertion
@@ -52,8 +51,7 @@ go_assert_list _ (_:_) [] = assertFailure "Less list elements than expected!"
 go_assert_list mk (head_exp:tail_exp) (head_act:tail_act) =
       mk head_exp head_act >> go_assert_list mk tail_exp tail_act
 
-assert_list :: forall a. ()
-            => (a -> a -> Assertion) -- ^ The function used to make an assertion on two elements (expected, actual)
+assert_list :: (a -> a -> Assertion) -- ^ The function used to make an assertion on two elements (expected, actual)
             -> [a]                   -- ^ The expected value
             -> [a]                   -- ^ The actual value
             -> Assertion
@@ -66,7 +64,7 @@ assert_list make_assert expected actual =
     lenE :: Int = length expected
     lenA :: Int = length actual
 
-assert_shape :: forall a sh. (VS.Storable a, OS.Shape sh)
+assert_shape :: (VS.Storable a, OS.Shape sh)
              => (a -> a -> Assertion) -- ^ The function used to make an assertion on two elements (expected, actual)
              -> OS.Array sh a         -- ^ The expected value
              -> OS.Array sh a         -- ^ The actual value
@@ -94,7 +92,7 @@ asList = foldr (:) []
 --
 -- If the prefix is the empty string (i.e., @\"\"@), then the prefix is omitted
 -- and only the expected and actual values are output.
-assertEqualUpToEps :: forall a. (Fractional a, Ord a, Show a, HasCallStack)
+assertEqualUpToEps :: (Fractional a, Ord a, Show a, HasCallStack)
                    => String -- ^ The message prefix
                    -> a      -- ^ The error margin
                    -> a      -- ^ The expected value
@@ -171,7 +169,7 @@ instance {-# OVERLAPPABLE #-} (VS.Storable a, OS.Shape sh1, AssertEqualUpToEpsil
 --
 -- If the prefix is the empty string (i.e., @\"\"@), then the prefix is omitted
 -- and only the expected and actual values are output.
-assertClose :: forall a. (Fractional a, Ord a, Show a, HasCallStack)
+assertClose :: (Fractional a, Ord a, Show a, HasCallStack)
             => String -- ^ The message prefix
             -> a      -- ^ The expected value
             -> a      -- ^ The actual value
@@ -198,7 +196,7 @@ assertCloseElem preface expected actual = do
       if abs (h-actual) < fromRational eqEps then assertClose msg h actual else go_assert eqEps t
 
 -- | Asserts that the specified actual floating point value list is close to the expected value.
-assertCloseList :: forall a. (AssertClose a)
+assertCloseList :: (AssertClose a)
                 => [a]      -- ^ The expected value
                 -> [a]      -- ^ The actual value
                 -> Assertion

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -106,14 +106,6 @@ assertEqualUpToEps preface eqEpsilon expected actual = do
                            "expected: " ++ show expected ++ "\n but got: " ++ show actual ++
                            "\n (maximum margin of error: " ++ show errorMargin ++ ")"
 
-assertEqualUpToEpsList :: forall a. (Fractional a, Ord a, Show a, HasCallStack)
-                       => String   -- ^ The message prefix
-                       -> a        -- ^ The error margin
-                       -> [a]      -- ^ The expected value
-                       -> [a]      -- ^ The actual value
-                       -> Assertion
-assertEqualUpToEpsList preface eqEpsilon = assert_list (assertEqualUpToEps preface eqEpsilon)
-
 ----------------------------------------------------------------------------
 -- AssertEqualUpToEpsilon class
 ----------------------------------------------------------------------------

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -108,17 +108,6 @@ assertEqualUpToEps preface eqEpsilon expected actual = do
                            "expected: " ++ show expected ++ "\n but got: " ++ show actual ++
                            "\n (maximum margin of error: " ++ show errorMargin ++ ")"
 
-assertEqualUpToEps3 :: forall a. (Fractional a, Ord a, Show a, HasCallStack)
-                    => String  -- ^ The message prefix
-                    -> a       -- ^ The error margin
-                    -> (a,a,a) -- ^ The expected value
-                    -> (a,a,a) -- ^ The actual value
-                    -> Assertion
-assertEqualUpToEps3 preface eqEpsilon (e1,e2,e3) (a1,a2,a3) =
-  assertEqualUpToEps preface eqEpsilon e1 a1 >>
-  assertEqualUpToEps preface eqEpsilon e2 a2 >>
-  assertEqualUpToEps preface eqEpsilon e3 a3
-
 assertEqualUpToEpsList :: forall a. (Fractional a, Ord a, Show a, HasCallStack)
                        => String   -- ^ The message prefix
                        -> a        -- ^ The error margin

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -93,13 +93,13 @@ as_list = foldr (:) []
 --
 -- If the prefix is the empty string (i.e., @\"\"@), then the prefix is omitted
 -- and only the expected and actual values are output.
-assertEqualUpToEps :: (Num a, Ord a, Show a, HasCallStack)
+assert_close_eps :: (Num a, Ord a, Show a, HasCallStack)
                    => String -- ^ The message prefix
                    -> a      -- ^ The error margin
                    -> a      -- ^ The expected value
                    -> a      -- ^ The actual value
                    -> Assertion
-assertEqualUpToEps preface eqEpsilon expected actual = do
+assert_close_eps preface eqEpsilon expected actual = do
   assertBool (msg eqEpsilon) (abs (expected-actual) < eqEpsilon)
   where msg errorMargin = (if null preface then "" else preface ++ "\n") ++
                            "expected: " ++ show expected ++ "\n but got: " ++ show actual ++
@@ -117,11 +117,11 @@ class (Fractional z) => AssertEqualUpToEpsilon z a | a -> z where
 
 instance {-# OVERLAPPABLE #-} AssertEqualUpToEpsilon Double Double where
   assertEqualUpToEpsilon :: Double -> Double -> Double -> Assertion
-  assertEqualUpToEpsilon = assertEqualUpToEps ""
+  assertEqualUpToEpsilon = assert_close_eps ""
 
 instance {-# OVERLAPPABLE #-} AssertEqualUpToEpsilon Float Float where
   assertEqualUpToEpsilon :: Float -> Float -> Float -> Assertion
-  assertEqualUpToEpsilon = assertEqualUpToEps ""
+  assertEqualUpToEpsilon = assert_close_eps ""
 
 instance {-# OVERLAPPABLE #-} (AssertEqualUpToEpsilon z a,
                                AssertEqualUpToEpsilon z b) => AssertEqualUpToEpsilon z (a,b) where
@@ -183,7 +183,7 @@ assertCloseElem preface expected actual = do
     go_assert :: Rational -> [a] -> Assertion
     go_assert _ [] = assertFailure msg
     go_assert eqEps (h:t) =
-      if abs (h-actual) < fromRational eqEps then assertEqualUpToEps msg (fromRational eqEps) h actual else go_assert eqEps t
+      if abs (h-actual) < fromRational eqEps then assert_close_eps msg (fromRational eqEps) h actual else go_assert eqEps t
 
 (@?~) :: (AssertEqualUpToEpsilon z a)
       => a -- ^ The actual value

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -80,10 +80,6 @@ assert_shape make_assert expected actual =
     shapeE = shapeL expected
     shapeA = shapeL actual
 
--- | Foldable to list.
-as_list :: Foldable t => t a -> [a]
-as_list = foldr (:) []
-
 ----------------------------------------------------------------------------
 -- Generic comparisons with explicit error margin
 ----------------------------------------------------------------------------
@@ -151,11 +147,6 @@ instance (AssertEqualUpToEpsilon z a,
     assertEqualUpToEpsilon eqEpsilon e3 a3 >>
     assertEqualUpToEpsilon eqEpsilon e4 a4
 
-instance {-# OVERLAPPABLE #-} (Foldable t, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (t a) where
-  assertEqualUpToEpsilon :: z -> t a -> t a -> Assertion
-  assertEqualUpToEpsilon eqEpsilon expected actual =
-    assert_list (assertEqualUpToEpsilon eqEpsilon) (as_list expected) (as_list actual)
-
 instance (VS.Storable a, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (VS.Vector a) where
   assertEqualUpToEpsilon :: z -> VS.Vector a -> VS.Vector a -> Assertion
   assertEqualUpToEpsilon eqEpsilon = assert_shape (assertEqualUpToEpsilon eqEpsilon)
@@ -164,9 +155,17 @@ instance (VS.Storable a, OS.Shape sh1, AssertEqualUpToEpsilon z a) => AssertEqua
   assertEqualUpToEpsilon :: z -> OS.Array sh1 a -> OS.Array sh1 a -> Assertion
   assertEqualUpToEpsilon eqEpsilon = assert_shape (assertEqualUpToEpsilon eqEpsilon)
 
-instance {-# OVERLAPPABLE #-} (Fractional z, HasShape a, Linearizable a b, AssertEqualUpToEpsilon z b) => AssertEqualUpToEpsilon z a where
-  assertEqualUpToEpsilon :: z -> a -> a -> Assertion
-  assertEqualUpToEpsilon eqEpsilon = assert_shape (assertEqualUpToEpsilon eqEpsilon)
+-- TODO: how do we make use of assert_shape in case (HasShape a)? Something like this (but this causes "duplicate instance declarations" error):
+--
+-- instance {-# OVERLAPPABLE #-} (Fractional z, HasShape t, Linearizable t a, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z t where
+--   assertEqualUpToEpsilon :: z -> a -> a -> Assertion
+--   assertEqualUpToEpsilon eqEpsilon = assert_shape (assertEqualUpToEpsilon eqEpsilon)
+--
+-- For now, we just use assert_list ...
+instance {-# OVERLAPPABLE #-} (Fractional z, Linearizable t a, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z t where
+  assertEqualUpToEpsilon :: z -> t -> t -> Assertion
+  assertEqualUpToEpsilon eqEpsilon expected actual =
+    assert_list (assertEqualUpToEpsilon eqEpsilon) (linearize expected) (linearize actual)
 
 ----------------------------------------------------------------------------
 -- Generic comparisons without explicit error margin

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -80,8 +80,8 @@ assert_shape make_assert expected actual =
     shapeA = OS.shapeL actual
 
 -- | Foldable to list.
-asList :: Foldable t => t a -> [a]
-asList = foldr (:) []
+as_list :: Foldable t => t a -> [a]
+as_list = foldr (:) []
 
 ----------------------------------------------------------------------------
 -- Generic comparisons with explicit error margin
@@ -153,7 +153,7 @@ instance {-# OVERLAPPABLE #-} (AssertEqualUpToEpsilon z a,
 instance {-# OVERLAPPABLE #-} (Traversable t, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (t a) where
   assertEqualUpToEpsilon :: z -> t a -> t a -> Assertion
   assertEqualUpToEpsilon eqEpsilon expected actual =
-    assert_list (assertEqualUpToEpsilon eqEpsilon) (asList expected) (asList actual)
+    assert_list (assertEqualUpToEpsilon eqEpsilon) (as_list expected) (as_list actual)
 
 instance {-# OVERLAPPABLE #-} (VS.Storable a, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (VS.Vector a) where
   assertEqualUpToEpsilon :: z -> VS.Vector a -> VS.Vector a -> Assertion

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -4,6 +4,8 @@ module TestCommonEqEpsilon (EqEpsilon, setEpsilonEq,
                             assertEqualUpToEps,
                             assertEqualUpToEps3,
                             assertEqualUpToEpsList,
+                            assertEqualUpToEpsVF,
+                            assertEqualUpToEpsS1,
                             assertEqualUpToEpsS,
                             assertCloseElem, (@?~)) where
 
@@ -95,6 +97,16 @@ assertEqualUpToEpsList :: forall a. (Fractional a, Ord a, Show a, HasCallStack)
                        -> Assertion
 assertEqualUpToEpsList preface eqEpsilon = assert_list (assertEqualUpToEps preface eqEpsilon)
 
+assertEqualUpToEpsS1 :: (OS.Shape sh1)
+                    => forall a . (Fractional a, Ord a, Show a, OS.Unbox a, HasCallStack)
+                    => String
+                    -> a
+                    -> (OS.Array sh1 a)
+                    -> (OS.Array sh1 a)
+                    -> Assertion
+assertEqualUpToEpsS1 preface eqEpsilon e1 a1 =
+  assertEqualUpToEpsList preface eqEpsilon (OS.toList e1) (OS.toList a1)
+
 assertEqualUpToEpsS :: (OS.Shape sh1, OS.Shape sh2, OS.Shape sh3, OS.Shape sh4)
                     => forall a . (Fractional a, Ord a, Show a, OS.Unbox a, HasCallStack)
                     => String
@@ -107,6 +119,13 @@ assertEqualUpToEpsS preface eqEpsilon (e1, e2, e3, e4) (a1, a2, a3, a4) =
   assertEqualUpToEpsList preface eqEpsilon (OS.toList e2) (OS.toList a2) >>
   assertEqualUpToEpsList preface eqEpsilon (OS.toList e3) (OS.toList a3) >>
   assertEqualUpToEpsList preface eqEpsilon (OS.toList e4) (OS.toList a4)
+
+
+assertEqualUpToEpsVF :: OS.Shape sh => Double -> OS.Array sh Double -> OS.Array sh Double -> Assertion
+assertEqualUpToEpsVF _eps r1 u1 =  -- TODO
+  OS.toList r1 @?~ OS.toList u1
+
+
 
 -- | Asserts that the specified actual floating point value is close to the expected value.
 -- The output message will contain the prefix, the expected value, and the

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -8,6 +8,7 @@ module TestCommonEqEpsilon (EqEpsilon, setEpsilonEq,
 import Data.Typeable
 import Prelude
 
+import qualified Data.Array.DynamicS as OT
 import qualified Data.Array.ShapedS as OS
 import           Data.IORef
 import qualified Data.Vector.Generic as VG
@@ -160,6 +161,11 @@ instance (VS.Storable a, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z
   assertEqualUpToEpsilon :: z -> VS.Vector a -> VS.Vector a -> Assertion
   assertEqualUpToEpsilon eqEpsilon expected actual =
     assert_list (assertEqualUpToEpsilon eqEpsilon) (VG.toList expected) (VG.toList actual)
+
+instance (VS.Storable a, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (OT.Array a) where
+  assertEqualUpToEpsilon :: z -> OT.Array a -> OT.Array a -> Assertion
+  assertEqualUpToEpsilon eqEpsilon expected actual =
+    assert_list (assertEqualUpToEpsilon eqEpsilon) (OT.toList expected) (OT.toList actual)
 
 instance (VS.Storable a, LA.Element a, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (LA.Matrix a) where
   assertEqualUpToEpsilon :: z -> LA.Matrix a -> LA.Matrix a -> Assertion

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -43,28 +43,27 @@ setEpsilonEq (EqEpsilon x) = atomicWriteIORef eqEpsilonRef x
 -- Helper functions
 ----------------------------------------------------------------------------
 
-go_assert_list :: (a -> a -> Assertion) -- ^ The function used to make an assertion on two elements (expected, actual)
-               -> [a]                   -- ^ The expected value
-               -> [a]                   -- ^ The actual value
-               -> Assertion
-go_assert_list _ [] [] = assertBool "" True
-go_assert_list _ [] (_:_) = assertFailure "More list elements than expected!"
-go_assert_list _ (_:_) [] = assertFailure "Less list elements than expected!"
-go_assert_list mk (head_exp:tail_exp) (head_act:tail_act) =
-      mk head_exp head_act >> go_assert_list mk tail_exp tail_act
-
-assert_list :: (a -> a -> Assertion) -- ^ The function used to make an assertion on two elements (expected, actual)
-            -> [a]                   -- ^ The expected value
-            -> [a]                   -- ^ The actual value
+assert_list :: forall a. (a -> a -> Assertion) -- ^ The function used to make an assertion on two elements (expected, actual)
+            -> [a]                             -- ^ The expected value
+            -> [a]                             -- ^ The actual value
             -> Assertion
 assert_list make_assert expected actual =
   if lenE == lenA then
-    go_assert_list make_assert expected actual
+    go_assert_list expected actual
   else
     assertFailure $ "List too " ++ (if lenE < lenA then "long" else "short") ++ ": expected " ++ show lenE ++ "elements, but got: " ++ show lenA
   where
     lenE :: Int = length expected
     lenA :: Int = length actual
+
+    go_assert_list :: [a]                   -- ^ The expected value
+                   -> [a]                   -- ^ The actual value
+                   -> Assertion
+    go_assert_list [] [] = assertBool "" True
+    go_assert_list [] (_:_) = assertFailure "More list elements than expected!"
+    go_assert_list (_:_) [] = assertFailure "Less list elements than expected!"
+    go_assert_list (head_exp:tail_exp) (head_act:tail_act) =
+          make_assert head_exp head_act >> go_assert_list tail_exp tail_act
 
 assert_shape :: forall a b. (HasShape a, Linearizable a b)
              => (b -> b -> Assertion) -- ^ The function used to make an assertion on two elements (expected, actual)

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -161,6 +161,11 @@ instance {-# OVERLAPPABLE #-} (AssertEqualUpToEpsilon z a,
     assertEqualUpToEpsilon eqEpsilon e2 a2 >>
     assertEqualUpToEpsilon eqEpsilon e3 a3
 
+instance {-# OVERLAPPABLE #-} (Traversable t, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (t a) where
+  assertEqualUpToEpsilon :: z -> t a -> t a -> Assertion
+  assertEqualUpToEpsilon eqEpsilon expected actual =
+    assert_list (assertEqualUpToEpsilon eqEpsilon) (asList expected) (asList actual)
+
 ----------------------------------------------------------------------------
 -- Generic comparisons without explicit error margin
 ----------------------------------------------------------------------------

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -108,13 +108,13 @@ assertEqualUpToEps preface eqEpsilon expected actual = do
 -- AssertEqualUpToEpsilon class
 ----------------------------------------------------------------------------
 
-class (Fractional z, Ord z, Show z) => AssertEqualUpToEpsilon z a where
+class AssertEqualUpToEpsilon z a where
   assertEqualUpToEpsilon :: z -- ^ The error margin (i.e., the epsilon)
                          -> a -- ^ The expected value
                          -> a -- ^ The actual value
                          -> Assertion
 
-instance {-# OVERLAPPABLE #-} (Fractional a, Ord a, Show a) => AssertEqualUpToEpsilon a a where
+instance {-# OVERLAPPABLE #-} (Num a, Ord a, Show a) => AssertEqualUpToEpsilon a a where
   assertEqualUpToEpsilon :: a -> a -> a -> Assertion
   assertEqualUpToEpsilon = assertEqualUpToEps ""
 

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -102,7 +102,7 @@ assert_close_eps preface epilogue eqEpsilon expected actual = do
     msg = "expected: " ++ show expected ++ "\n but got: " ++ show actual
     message errorMargin = (if null preface then "" else preface ++ "\n") ++
                           msg ++ "\n (maximum margin of error: " ++ show errorMargin ++ ")" ++
-                          (if (null epilogue) ||
+                          (if null epilogue ||
                               (lowercase epilogue == lowercase preface) ||
                               (lowercase epilogue == lowercase msg) then "" else "\n" ++ epilogue)
 
@@ -123,7 +123,7 @@ class (Fractional z, Show a) => AssertEqualUpToEpsilon z a | a -> z where
                          -> a -- ^ The actual value
                          -> Assertion
   assertEqualUpToEpsilon error_margin expected actual =
-    assertEqualUpToEpsilonWithMsg ("Expected: " ++ (show expected) ++ "\n but got: " ++ (show actual)) error_margin expected actual
+    assertEqualUpToEpsilonWithMsg ("Expected: " ++ show expected ++ "\n but got: " ++ show actual) error_margin expected actual
 
 instance AssertEqualUpToEpsilon Double Double where
   assertEqualUpToEpsilonWithMsg :: String -> Double -> Double -> Double -> Assertion

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving,
+{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses,
              UndecidableInstances #-}
 module TestCommonEqEpsilon (EqEpsilon, setEpsilonEq,
                             assertEqualUpToEps,
@@ -130,6 +130,20 @@ assertEqualUpToEpsShape4 preface eqEpsilon (e1, e2, e3, e4) (a1, a2, a3, a4) =
   assertEqualUpToEpsList preface eqEpsilon (OS.toList e2) (OS.toList a2) >>
   assertEqualUpToEpsList preface eqEpsilon (OS.toList e3) (OS.toList a3) >>
   assertEqualUpToEpsList preface eqEpsilon (OS.toList e4) (OS.toList a4)
+
+----------------------------------------------------------------------------
+-- AssertEqualUpToEpsilon class
+----------------------------------------------------------------------------
+
+class (Fractional e, Ord e, Show e) => AssertEqualUpToEpsilon a e where
+  assertEqualUpToEpsilon :: e -- ^ The error margin (i.e., the epsilon)
+                         -> a -- ^ The expected value
+                         -> a -- ^ The actual value
+                         -> Assertion
+
+instance {-# OVERLAPPABLE #-} (Fractional a, Ord a, Show a) => AssertEqualUpToEpsilon a a where
+  assertEqualUpToEpsilon :: a -> a -> a -> Assertion
+  assertEqualUpToEpsilon = assertEqualUpToEps ""
 
 ----------------------------------------------------------------------------
 -- Generic comparisons without explicit error margin

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -24,7 +24,7 @@ instance IsOption EqEpsilon where
   defaultValue = EqEpsilon eqEpsilonDefault
   parseValue s = fmap (EqEpsilon . toRational) ((safeRead :: String -> Maybe Double) s)
   optionName = return "eq-epsilon"
-  optionHelp = return $ "Epsilon to use for floating point comparisons: abs(a-b) < epsilon . Default: " ++ show eqEpsilonDefault
+  optionHelp = return $ "Epsilon to use for floating point comparisons: abs(a-b) < epsilon . Default: " ++ show (fromRational eqEpsilonDefault :: Double)
 
 -- Default value for eqEpsilonRef
 eqEpsilonDefault :: Rational

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -151,7 +151,7 @@ instance (AssertEqualUpToEpsilon z a,
     assertEqualUpToEpsilon eqEpsilon e3 a3 >>
     assertEqualUpToEpsilon eqEpsilon e4 a4
 
-instance {-# OVERLAPPABLE #-} (Traversable t, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (t a) where
+instance (Traversable t, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (t a) where
   assertEqualUpToEpsilon :: z -> t a -> t a -> Assertion
   assertEqualUpToEpsilon eqEpsilon expected actual =
     assert_list (assertEqualUpToEpsilon eqEpsilon) (as_list expected) (as_list actual)

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -161,11 +161,11 @@ instance (VS.Storable a, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z
   assertEqualUpToEpsilon eqEpsilon expected actual =
     assert_list (assertEqualUpToEpsilon eqEpsilon) (VS.toList expected) (VS.toList actual)
 
-instance {-# OVERLAPPABLE #-} (VS.Storable a, OS.Shape sh1, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (OS.Array sh1 a) where
+instance (VS.Storable a, OS.Shape sh1, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (OS.Array sh1 a) where
   assertEqualUpToEpsilon :: z -> OS.Array sh1 a -> OS.Array sh1 a -> Assertion
   assertEqualUpToEpsilon eqEpsilon = assert_shape (assertEqualUpToEpsilon eqEpsilon)
 
-instance {-# OVERLAPPABLE #-} (Fractional z, HasShape a, Linearizable a b, AssertEqualUpToEpsilon z b) => AssertEqualUpToEpsilon z a where
+instance (Fractional z, HasShape a, Linearizable a b, AssertEqualUpToEpsilon z b) => AssertEqualUpToEpsilon z a where
   assertEqualUpToEpsilon :: z -> a -> a -> Assertion
   assertEqualUpToEpsilon eqEpsilon = assert_shape (assertEqualUpToEpsilon eqEpsilon)
 

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -68,8 +68,8 @@ assert_list make_assert expected actual =
 
 assert_shape :: forall a sh. (VS.Storable a, OS.Shape sh)
              => (a -> a -> Assertion) -- ^ The function used to make an assertion on two elements (expected, actual)
-             -> (OS.Array sh a)       -- ^ The expected value
-             -> (OS.Array sh a)       -- ^ The actual value
+             -> OS.Array sh a         -- ^ The expected value
+             -> OS.Array sh a         -- ^ The actual value
              -> Assertion
 assert_shape make_assert expected actual =
   if shapeE == shapeA then

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -80,10 +80,6 @@ assert_shape make_assert expected actual =
     shapeE = shapeL expected
     shapeA = shapeL actual
 
--- | Foldable to list.
-as_list :: Foldable t => t a -> [a]
-as_list = foldr (:) []
-
 ----------------------------------------------------------------------------
 -- Generic comparisons with explicit error margin
 ----------------------------------------------------------------------------
@@ -155,7 +151,7 @@ instance (VS.Storable a, OS.Shape sh1, AssertEqualUpToEpsilon z a) => AssertEqua
   assertEqualUpToEpsilon :: z -> OS.Array sh1 a -> OS.Array sh1 a -> Assertion
   assertEqualUpToEpsilon eqEpsilon = assert_shape (assertEqualUpToEpsilon eqEpsilon)
 
-instance (Fractional z, HasShape a, Linearizable a b, AssertEqualUpToEpsilon z b) => AssertEqualUpToEpsilon z a where
+instance {-# OVERLAPPABLE #-} (Fractional z, HasShape a, Linearizable a b, AssertEqualUpToEpsilon z b) => AssertEqualUpToEpsilon z a where
   assertEqualUpToEpsilon :: z -> a -> a -> Assertion
   assertEqualUpToEpsilon eqEpsilon = assert_shape (assertEqualUpToEpsilon eqEpsilon)
 

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -4,11 +4,13 @@ module TestCommonEqEpsilon (EqEpsilon, setEpsilonEq,
                             assertEqualUpToEps,
                             assertEqualUpToEps3,
                             assertEqualUpToEpsList,
+                            assertEqualUpToEpsS,
                             assertCloseElem, (@?~)) where
 
 import Data.Typeable
 import Prelude
 
+import qualified Data.Array.ShapedS as OS
 import           Data.IORef
 import qualified Data.Vector.Generic as VG
 import qualified Data.Vector.Storable as VS
@@ -92,6 +94,19 @@ assertEqualUpToEpsList :: forall a. (Fractional a, Ord a, Show a, HasCallStack)
                        -> [a]      -- ^ The actual value
                        -> Assertion
 assertEqualUpToEpsList preface eqEpsilon = assert_list (assertEqualUpToEps preface eqEpsilon)
+
+assertEqualUpToEpsS :: (OS.Shape sh1, OS.Shape sh2, OS.Shape sh3, OS.Shape sh4)
+                    => forall a . (Fractional a, Ord a, Show a, OS.Unbox a, HasCallStack)
+                    => String
+                    -> a
+                    -> (OS.Array sh1 a, OS.Array sh2 a, OS.Array sh3 a, OS.Array sh4 a)
+                    -> (OS.Array sh1 a, OS.Array sh2 a, OS.Array sh3 a, OS.Array sh4 a)
+                    -> Assertion
+assertEqualUpToEpsS preface eqEpsilon (e1, e2, e3, e4) (a1, a2, a3, a4) =
+  assertEqualUpToEpsList preface eqEpsilon (OS.toList e1) (OS.toList a1) >>
+  assertEqualUpToEpsList preface eqEpsilon (OS.toList e2) (OS.toList a2) >>
+  assertEqualUpToEpsList preface eqEpsilon (OS.toList e3) (OS.toList a3) >>
+  assertEqualUpToEpsList preface eqEpsilon (OS.toList e4) (OS.toList a4)
 
 -- | Asserts that the specified actual floating point value is close to the expected value.
 -- The output message will contain the prefix, the expected value, and the

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -157,6 +157,114 @@ instance (AssertEqualUpToEpsilon z a,
     assertEqualUpToEpsilonWithMsg msg eqEpsilon e3 a3 >>
     assertEqualUpToEpsilonWithMsg msg eqEpsilon e4 a4
 
+instance (AssertEqualUpToEpsilon z a,
+          AssertEqualUpToEpsilon z b,
+          AssertEqualUpToEpsilon z c,
+          AssertEqualUpToEpsilon z d,
+          AssertEqualUpToEpsilon z e) => AssertEqualUpToEpsilon z (a,b,c,d,e) where
+  assertEqualUpToEpsilonWithMsg :: String -> z -> (a,b,c,d,e) -> (a,b,c,d,e) -> Assertion
+  assertEqualUpToEpsilonWithMsg msg eqEpsilon (e1,e2,e3,e4,e5) (a1,a2,a3,a4,a5) =
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e1 a1 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e2 a2 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e3 a3 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e4 a4 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e5 a5
+
+instance (AssertEqualUpToEpsilon z a,
+          AssertEqualUpToEpsilon z b,
+          AssertEqualUpToEpsilon z c,
+          AssertEqualUpToEpsilon z d,
+          AssertEqualUpToEpsilon z e,
+          AssertEqualUpToEpsilon z f) => AssertEqualUpToEpsilon z (a,b,c,d,e,f) where
+  assertEqualUpToEpsilonWithMsg :: String -> z -> (a,b,c,d,e,f) -> (a,b,c,d,e,f) -> Assertion
+  assertEqualUpToEpsilonWithMsg msg eqEpsilon (e1,e2,e3,e4,e5,e6) (a1,a2,a3,a4,a5,a6) =
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e1 a1 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e2 a2 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e3 a3 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e4 a4 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e5 a5 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e6 a6
+
+instance (AssertEqualUpToEpsilon z a,
+          AssertEqualUpToEpsilon z b,
+          AssertEqualUpToEpsilon z c,
+          AssertEqualUpToEpsilon z d,
+          AssertEqualUpToEpsilon z e,
+          AssertEqualUpToEpsilon z f,
+          AssertEqualUpToEpsilon z g) => AssertEqualUpToEpsilon z (a,b,c,d,e,f,g) where
+  assertEqualUpToEpsilonWithMsg :: String -> z -> (a,b,c,d,e,f,g) -> (a,b,c,d,e,f,g) -> Assertion
+  assertEqualUpToEpsilonWithMsg msg eqEpsilon (e1,e2,e3,e4,e5,e6,e7) (a1,a2,a3,a4,a5,a6,a7) =
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e1 a1 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e2 a2 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e3 a3 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e4 a4 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e5 a5 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e6 a6 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e7 a7
+
+instance (AssertEqualUpToEpsilon z a,
+          AssertEqualUpToEpsilon z b,
+          AssertEqualUpToEpsilon z c,
+          AssertEqualUpToEpsilon z d,
+          AssertEqualUpToEpsilon z e,
+          AssertEqualUpToEpsilon z f,
+          AssertEqualUpToEpsilon z g,
+          AssertEqualUpToEpsilon z h) => AssertEqualUpToEpsilon z (a,b,c,d,e,f,g,h) where
+  assertEqualUpToEpsilonWithMsg :: String -> z -> (a,b,c,d,e,f,g,h) -> (a,b,c,d,e,f,g,h) -> Assertion
+  assertEqualUpToEpsilonWithMsg msg eqEpsilon (e1,e2,e3,e4,e5,e6,e7,e8) (a1,a2,a3,a4,a5,a6,a7,a8) =
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e1 a1 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e2 a2 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e3 a3 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e4 a4 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e5 a5 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e6 a6 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e7 a7 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e8 a8
+
+instance (AssertEqualUpToEpsilon z a,
+          AssertEqualUpToEpsilon z b,
+          AssertEqualUpToEpsilon z c,
+          AssertEqualUpToEpsilon z d,
+          AssertEqualUpToEpsilon z e,
+          AssertEqualUpToEpsilon z f,
+          AssertEqualUpToEpsilon z g,
+          AssertEqualUpToEpsilon z h,
+          AssertEqualUpToEpsilon z i) => AssertEqualUpToEpsilon z (a,b,c,d,e,f,g,h,i) where
+  assertEqualUpToEpsilonWithMsg :: String -> z -> (a,b,c,d,e,f,g,h,i) -> (a,b,c,d,e,f,g,h,i) -> Assertion
+  assertEqualUpToEpsilonWithMsg msg eqEpsilon (e1,e2,e3,e4,e5,e6,e7,e8,e9) (a1,a2,a3,a4,a5,a6,a7,a8,a9) =
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e1 a1 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e2 a2 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e3 a3 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e4 a4 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e5 a5 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e6 a6 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e7 a7 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e8 a8 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e9 a9
+
+instance (AssertEqualUpToEpsilon z a,
+          AssertEqualUpToEpsilon z b,
+          AssertEqualUpToEpsilon z c,
+          AssertEqualUpToEpsilon z d,
+          AssertEqualUpToEpsilon z e,
+          AssertEqualUpToEpsilon z f,
+          AssertEqualUpToEpsilon z g,
+          AssertEqualUpToEpsilon z h,
+          AssertEqualUpToEpsilon z i,
+          AssertEqualUpToEpsilon z j) => AssertEqualUpToEpsilon z (a,b,c,d,e,f,g,h,i,j) where
+  assertEqualUpToEpsilonWithMsg :: String -> z -> (a,b,c,d,e,f,g,h,i,j) -> (a,b,c,d,e,f,g,h,i,j) -> Assertion
+  assertEqualUpToEpsilonWithMsg msg eqEpsilon (e1,e2,e3,e4,e5,e6,e7,e8,e9,e10) (a1,a2,a3,a4,a5,a6,a7,a8,a9,a10) =
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e1  a1 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e2  a2 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e3  a3 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e4  a4 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e5  a5 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e6  a6 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e7  a7 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e8  a8 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e9  a9 >>
+    assertEqualUpToEpsilonWithMsg msg eqEpsilon e10 a10
+
 instance (VS.Storable a, OS.Shape sh1, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (OS.Array sh1 a) where
   assertEqualUpToEpsilonWithMsg :: String -> z -> OS.Array sh1 a -> OS.Array sh1 a -> Assertion
   assertEqualUpToEpsilonWithMsg msg eqEpsilon expected actual = assert_list (assertEqualUpToEpsilonWithMsg msg eqEpsilon) (linearize expected) (linearize actual)

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -166,6 +166,11 @@ instance {-# OVERLAPPABLE #-} (Traversable t, AssertEqualUpToEpsilon z a) => Ass
   assertEqualUpToEpsilon eqEpsilon expected actual =
     assert_list (assertEqualUpToEpsilon eqEpsilon) (asList expected) (asList actual)
 
+instance {-# OVERLAPPABLE #-} (VS.Storable a, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (VS.Vector a) where
+  assertEqualUpToEpsilon :: z -> VS.Vector a -> VS.Vector a -> Assertion
+  assertEqualUpToEpsilon eqEpsilon expected actual =
+    assert_list (assertEqualUpToEpsilon eqEpsilon) (VG.toList expected) (VG.toList actual)
+
 ----------------------------------------------------------------------------
 -- Generic comparisons without explicit error margin
 ----------------------------------------------------------------------------

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -5,8 +5,8 @@ module TestCommonEqEpsilon (EqEpsilon, setEpsilonEq,
                             assertEqualUpToEps3,
                             assertEqualUpToEpsList,
                             assertEqualUpToEpsVF,
-                            assertEqualUpToEpsS1,
-                            assertEqualUpToEpsS,
+                            assertEqualUpToEpsShape1,
+                            assertEqualUpToEpsShape4,
                             assertCloseElem, (@?~)) where
 
 import Data.Typeable
@@ -97,35 +97,32 @@ assertEqualUpToEpsList :: forall a. (Fractional a, Ord a, Show a, HasCallStack)
                        -> Assertion
 assertEqualUpToEpsList preface eqEpsilon = assert_list (assertEqualUpToEps preface eqEpsilon)
 
-assertEqualUpToEpsS1 :: (OS.Shape sh1)
+assertEqualUpToEpsShape1 :: (OS.Shape sh1)
                     => forall a . (Fractional a, Ord a, Show a, OS.Unbox a, HasCallStack)
                     => String
                     -> a
                     -> (OS.Array sh1 a)
                     -> (OS.Array sh1 a)
                     -> Assertion
-assertEqualUpToEpsS1 preface eqEpsilon e1 a1 =
+assertEqualUpToEpsShape1 preface eqEpsilon e1 a1 =
   assertEqualUpToEpsList preface eqEpsilon (OS.toList e1) (OS.toList a1)
 
-assertEqualUpToEpsS :: (OS.Shape sh1, OS.Shape sh2, OS.Shape sh3, OS.Shape sh4)
+assertEqualUpToEpsShape4 :: (OS.Shape sh1, OS.Shape sh2, OS.Shape sh3, OS.Shape sh4)
                     => forall a . (Fractional a, Ord a, Show a, OS.Unbox a, HasCallStack)
                     => String
                     -> a
                     -> (OS.Array sh1 a, OS.Array sh2 a, OS.Array sh3 a, OS.Array sh4 a)
                     -> (OS.Array sh1 a, OS.Array sh2 a, OS.Array sh3 a, OS.Array sh4 a)
                     -> Assertion
-assertEqualUpToEpsS preface eqEpsilon (e1, e2, e3, e4) (a1, a2, a3, a4) =
+assertEqualUpToEpsShape4 preface eqEpsilon (e1, e2, e3, e4) (a1, a2, a3, a4) =
   assertEqualUpToEpsList preface eqEpsilon (OS.toList e1) (OS.toList a1) >>
   assertEqualUpToEpsList preface eqEpsilon (OS.toList e2) (OS.toList a2) >>
   assertEqualUpToEpsList preface eqEpsilon (OS.toList e3) (OS.toList a3) >>
   assertEqualUpToEpsList preface eqEpsilon (OS.toList e4) (OS.toList a4)
 
-
 assertEqualUpToEpsVF :: OS.Shape sh => Double -> OS.Array sh Double -> OS.Array sh Double -> Assertion
 assertEqualUpToEpsVF _eps r1 u1 =  -- TODO
   OS.toList r1 @?~ OS.toList u1
-
-
 
 -- | Asserts that the specified actual floating point value is close to the expected value.
 -- The output message will contain the prefix, the expected value, and the

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses,
              UndecidableInstances #-}
 module TestCommonEqEpsilon (EqEpsilon, setEpsilonEq,
-                            assertEqualUpToEpsShape4,
                             assertEqualUpToEpsilon,
                             assertCloseElem, (@?~)) where
 
@@ -115,19 +114,6 @@ assertEqualUpToEpsList :: forall a. (Fractional a, Ord a, Show a, HasCallStack)
                        -> Assertion
 assertEqualUpToEpsList preface eqEpsilon = assert_list (assertEqualUpToEps preface eqEpsilon)
 
-assertEqualUpToEpsShape4 :: (OS.Shape sh1, OS.Shape sh2, OS.Shape sh3, OS.Shape sh4)
-                    => forall a . (Fractional a, Ord a, Show a, OS.Unbox a, HasCallStack)
-                    => String
-                    -> a
-                    -> (OS.Array sh1 a, OS.Array sh2 a, OS.Array sh3 a, OS.Array sh4 a)
-                    -> (OS.Array sh1 a, OS.Array sh2 a, OS.Array sh3 a, OS.Array sh4 a)
-                    -> Assertion
-assertEqualUpToEpsShape4 preface eqEpsilon (e1, e2, e3, e4) (a1, a2, a3, a4) =
-  assertEqualUpToEpsList preface eqEpsilon (OS.toList e1) (OS.toList a1) >>
-  assertEqualUpToEpsList preface eqEpsilon (OS.toList e2) (OS.toList a2) >>
-  assertEqualUpToEpsList preface eqEpsilon (OS.toList e3) (OS.toList a3) >>
-  assertEqualUpToEpsList preface eqEpsilon (OS.toList e4) (OS.toList a4)
-
 ----------------------------------------------------------------------------
 -- AssertEqualUpToEpsilon class
 ----------------------------------------------------------------------------
@@ -157,6 +143,17 @@ instance {-# OVERLAPPABLE #-} (AssertEqualUpToEpsilon z a,
     assertEqualUpToEpsilon eqEpsilon e1 a1 >>
     assertEqualUpToEpsilon eqEpsilon e2 a2 >>
     assertEqualUpToEpsilon eqEpsilon e3 a3
+
+instance {-# OVERLAPPABLE #-} (AssertEqualUpToEpsilon z a,
+                               AssertEqualUpToEpsilon z b,
+                               AssertEqualUpToEpsilon z c,
+                               AssertEqualUpToEpsilon z d) => AssertEqualUpToEpsilon z (a,b,c,d) where
+  assertEqualUpToEpsilon :: z -> (a,b,c,d) -> (a,b,c,d) -> Assertion
+  assertEqualUpToEpsilon eqEpsilon (e1,e2,e3,e4) (a1,a2,a3,a4) =
+    assertEqualUpToEpsilon eqEpsilon e1 a1 >>
+    assertEqualUpToEpsilon eqEpsilon e2 a2 >>
+    assertEqualUpToEpsilon eqEpsilon e3 a3 >>
+    assertEqualUpToEpsilon eqEpsilon e4 a4
 
 instance {-# OVERLAPPABLE #-} (Traversable t, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (t a) where
   assertEqualUpToEpsilon :: z -> t a -> t a -> Assertion

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -24,7 +24,7 @@ instance IsOption EqEpsilon where
   defaultValue = EqEpsilon eqEpsilonDefault
   parseValue s = fmap (EqEpsilon . toRational) ((safeRead :: String -> Maybe Double) s)
   optionName = return "eq-epsilon"
-  optionHelp = return $ "Epsilon to use for floating point comparisons: abs(a-b) < epsilon . Default: " ++ show (fromRational eqEpsilonDefault :: Double)
+  optionHelp = return $ "Epsilon to use for floating point comparisons: abs(a-b) <= epsilon . Default: " ++ show (fromRational eqEpsilonDefault :: Double)
 
 -- Default value for eqEpsilonRef
 eqEpsilonDefault :: Rational
@@ -98,7 +98,7 @@ assert_close_eps :: (Num a, Ord a, Show a, HasCallStack)
                    -> a      -- ^ The actual value
                    -> Assertion
 assert_close_eps preface epilogue eqEpsilon expected actual = do
-  assertBool (msg eqEpsilon) (abs (expected-actual) < eqEpsilon)
+  assertBool (msg eqEpsilon) (abs (expected-actual) <= eqEpsilon)
   where msg errorMargin = (if null preface then "" else preface ++ "\n") ++
                            "expected: " ++ show expected ++ "\n but got: " ++ show actual ++
                            "\n (maximum margin of error: " ++ show errorMargin ++ ")" ++
@@ -185,7 +185,7 @@ assertCloseElem preface expected actual = do
     go_assert :: Rational -> [a] -> Assertion
     go_assert _ [] = assertFailure msg
     go_assert eqEps (h:t) =
-      if abs (h-actual) < fromRational eqEps then assert_close_eps msg "" (fromRational eqEps) h actual else go_assert eqEps t
+      if abs (h-actual) <= fromRational eqEps then assert_close_eps msg "" (fromRational eqEps) h actual else go_assert eqEps t
 
 assertClose :: (AssertEqualUpToEpsilon z a)
       => a -- ^ The expected value

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -10,7 +10,6 @@ import Prelude
 
 import qualified Data.Array.ShapedS as OS
 import           Data.IORef
-import           Distribution.Simple.Utils (lowercase)
 import qualified Data.Vector.Storable as VS
 import           System.IO.Unsafe
 import           Test.Tasty.HUnit
@@ -101,10 +100,11 @@ assert_close_eps preface epilogue eqEpsilon expected actual = do
   assertBool (message eqEpsilon) (abs (expected-actual) <= eqEpsilon)
   where
     msg = "expected: " ++ show expected ++ "\n but got: " ++ show actual
-    t = lowercase
     message errorMargin = (if null preface then "" else preface ++ "\n") ++
                           msg ++ "\n (maximum margin of error: " ++ show errorMargin ++ ")" ++
-                          (if (null epilogue) || (t epilogue == t preface) || (t epilogue == t msg) then "" else "\n" ++ epilogue)
+                          (if (null epilogue) ||
+                              (lowercase epilogue == lowercase preface) ||
+                              (lowercase epilogue == lowercase msg) then "" else "\n" ++ epilogue)
 
 ----------------------------------------------------------------------------
 -- AssertEqualUpToEpsilon class

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -4,7 +4,6 @@ module TestCommonEqEpsilon (EqEpsilon, setEpsilonEq,
                             assertEqualUpToEps,
                             assertEqualUpToEps3,
                             assertEqualUpToEpsList,
-                            assertEqualUpToEpsVF,
                             assertEqualUpToEpsShape1,
                             assertEqualUpToEpsShape4,
                             assertCloseElem, (@?~)) where
@@ -119,10 +118,6 @@ assertEqualUpToEpsShape4 preface eqEpsilon (e1, e2, e3, e4) (a1, a2, a3, a4) =
   assertEqualUpToEpsList preface eqEpsilon (OS.toList e2) (OS.toList a2) >>
   assertEqualUpToEpsList preface eqEpsilon (OS.toList e3) (OS.toList a3) >>
   assertEqualUpToEpsList preface eqEpsilon (OS.toList e4) (OS.toList a4)
-
-assertEqualUpToEpsVF :: OS.Shape sh => Double -> OS.Array sh Double -> OS.Array sh Double -> Assertion
-assertEqualUpToEpsVF _eps r1 u1 =  -- TODO
-  OS.toList r1 @?~ OS.toList u1
 
 -- | Asserts that the specified actual floating point value is close to the expected value.
 -- The output message will contain the prefix, the expected value, and the

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -1,11 +1,9 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses,
              UndecidableInstances #-}
 module TestCommonEqEpsilon (EqEpsilon, setEpsilonEq,
-                            assertEqualUpToEps,
-                            assertEqualUpToEps3,
-                            assertEqualUpToEpsList,
                             assertEqualUpToEpsShape1,
                             assertEqualUpToEpsShape4,
+                            assertEqualUpToEpsilon,
                             assertCloseElem, (@?~)) where
 
 import Data.Typeable

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses,
              UndecidableInstances #-}
 module TestCommonEqEpsilon (EqEpsilon, setEpsilonEq,
-                            assertEqualUpToEpsShape1,
                             assertEqualUpToEpsShape4,
                             assertEqualUpToEpsilon,
                             assertCloseElem, (@?~)) where
@@ -115,16 +114,6 @@ assertEqualUpToEpsList :: forall a. (Fractional a, Ord a, Show a, HasCallStack)
                        -> [a]      -- ^ The actual value
                        -> Assertion
 assertEqualUpToEpsList preface eqEpsilon = assert_list (assertEqualUpToEps preface eqEpsilon)
-
-assertEqualUpToEpsShape1 :: (OS.Shape sh1)
-                    => forall a . (Fractional a, Ord a, Show a, OS.Unbox a, HasCallStack)
-                    => String
-                    -> a
-                    -> (OS.Array sh1 a)
-                    -> (OS.Array sh1 a)
-                    -> Assertion
-assertEqualUpToEpsShape1 preface eqEpsilon e1 a1 =
-  assertEqualUpToEpsList preface eqEpsilon (OS.toList e1) (OS.toList a1)
 
 assertEqualUpToEpsShape4 :: (OS.Shape sh1, OS.Shape sh2, OS.Shape sh3, OS.Shape sh4)
                     => forall a . (Fractional a, Ord a, Show a, OS.Unbox a, HasCallStack)

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -12,6 +12,7 @@ import qualified Data.Array.ShapedS as OS
 import           Data.IORef
 import qualified Data.Vector.Generic as VG
 import qualified Data.Vector.Storable as VS
+import qualified Numeric.LinearAlgebra as LA
 import           System.IO.Unsafe
 import           Test.Tasty.HUnit
 import           Test.Tasty.Options
@@ -159,6 +160,11 @@ instance (VS.Storable a, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z
   assertEqualUpToEpsilon :: z -> VS.Vector a -> VS.Vector a -> Assertion
   assertEqualUpToEpsilon eqEpsilon expected actual =
     assert_list (assertEqualUpToEpsilon eqEpsilon) (VG.toList expected) (VG.toList actual)
+
+instance (VS.Storable a, LA.Element a, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (LA.Matrix a) where
+  assertEqualUpToEpsilon :: z -> LA.Matrix a -> LA.Matrix a -> Assertion
+  assertEqualUpToEpsilon eqEpsilon expected actual =
+    assert_list (assertEqualUpToEpsilon eqEpsilon) (VG.toList $ LA.flatten expected) (VG.toList $ LA.flatten actual)
 
 instance (VS.Storable a, OS.Shape sh1, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (OS.Array sh1 a) where
   assertEqualUpToEpsilon :: z -> OS.Array sh1 a -> OS.Array sh1 a -> Assertion

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -135,8 +135,8 @@ assertEqualUpToEpsShape4 preface eqEpsilon (e1, e2, e3, e4) (a1, a2, a3, a4) =
 -- AssertEqualUpToEpsilon class
 ----------------------------------------------------------------------------
 
-class (Fractional e, Ord e, Show e) => AssertEqualUpToEpsilon a e where
-  assertEqualUpToEpsilon :: e -- ^ The error margin (i.e., the epsilon)
+class (Fractional z, Ord z, Show z) => AssertEqualUpToEpsilon z a where
+  assertEqualUpToEpsilon :: z -- ^ The error margin (i.e., the epsilon)
                          -> a -- ^ The expected value
                          -> a -- ^ The actual value
                          -> Assertion
@@ -144,6 +144,13 @@ class (Fractional e, Ord e, Show e) => AssertEqualUpToEpsilon a e where
 instance {-# OVERLAPPABLE #-} (Fractional a, Ord a, Show a) => AssertEqualUpToEpsilon a a where
   assertEqualUpToEpsilon :: a -> a -> a -> Assertion
   assertEqualUpToEpsilon = assertEqualUpToEps ""
+
+instance {-# OVERLAPPABLE #-} (AssertEqualUpToEpsilon z a,
+                               AssertEqualUpToEpsilon z b) => AssertEqualUpToEpsilon z (a,b) where
+  assertEqualUpToEpsilon :: z -> (a,b) -> (a,b) -> Assertion
+  assertEqualUpToEpsilon eqEpsilon (e1,e2) (a1,a2) =
+    assertEqualUpToEpsilon eqEpsilon e1 a1 >>
+    assertEqualUpToEpsilon eqEpsilon e2 a2
 
 ----------------------------------------------------------------------------
 -- Generic comparisons without explicit error margin

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -192,6 +192,10 @@ instance {-# OVERLAPPABLE #-} (VS.Storable a, AssertEqualUpToEpsilon z a) => Ass
   assertEqualUpToEpsilon eqEpsilon expected actual =
     assert_list (assertEqualUpToEpsilon eqEpsilon) (VG.toList expected) (VG.toList actual)
 
+instance {-# OVERLAPPABLE #-} (VS.Storable a, OS.Shape sh1, AssertEqualUpToEpsilon z a) => AssertEqualUpToEpsilon z (OS.Array sh1 a) where
+  assertEqualUpToEpsilon :: z -> OS.Array sh1 a -> OS.Array sh1 a -> Assertion
+  assertEqualUpToEpsilon eqEpsilon = assert_shape (assertEqualUpToEpsilon eqEpsilon)
+
 ----------------------------------------------------------------------------
 -- Generic comparisons without explicit error margin
 ----------------------------------------------------------------------------

--- a/test/common/TestCommonEqEpsilon.hs
+++ b/test/common/TestCommonEqEpsilon.hs
@@ -24,7 +24,7 @@ instance IsOption EqEpsilon where
   defaultValue = EqEpsilon eqEpsilonDefault
   parseValue s = fmap (EqEpsilon . toRational) ((safeRead :: String -> Maybe Double) s)
   optionName = return "eq-epsilon"
-  optionHelp = return $ "Epsilon to use for floating point comparisons: abs(a-b) <= epsilon . Default: " ++ show (fromRational eqEpsilonDefault :: Double)
+  optionHelp = return $ "Epsilon to use for floating point comparisons: abs(a-b) <= epsilon. Default: " ++ show (fromRational eqEpsilonDefault :: Double)
 
 -- Default value for eqEpsilonRef
 eqEpsilonDefault :: Rational

--- a/test/common/TestSingleGradient.hs
+++ b/test/common/TestSingleGradient.hs
@@ -516,7 +516,7 @@ fooS MkSN MkSN MkSN MkSN (x1, x2, x3, x4) =
 
 testFooS :: Assertion
 testFooS =
-  assertEqualUpToEpsS @'[1] @'[5] @'[3] @'[4] (1e-10 :: Double)
+  assertEqualUpToEpsS @'[1] @'[5] @'[3] @'[4] "testFooS" (1e-10 :: Double)
     (rev (fooS (MkSN @1) (MkSN @5) (MkSN @3) (MkSN @4))
           ( OS.fromList [1.1]
           , OS.fromList [2.2, 2.3, 7.2, 7.3, 7.4]
@@ -760,18 +760,6 @@ instance (ADModeAndNum d r, OS.Shape sh, KnownNat n1, KnownNat n2)
 
 
 -- * assertEqualUpToEps hacks (#65)
-
-assertEqualUpToEpsS :: (OS.Shape sh1, OS.Shape sh2, OS.Shape sh3, OS.Shape sh4)
-                    => forall a . (Fractional a, Ord a, Show a, OS.Unbox a, HasCallStack)
-                    => a
-                    -> (OS.Array sh1 a, OS.Array sh2 a, OS.Array sh3 a, OS.Array sh4 a)
-                    -> (OS.Array sh1 a, OS.Array sh2 a, OS.Array sh3 a, OS.Array sh4 a)
-                    -> Assertion
-assertEqualUpToEpsS eqEpsilon (e1, e2, e3, e4) (a1, a2, a3, a4) =
-  assertEqualUpToEpsList "" eqEpsilon (OS.toList e1) (OS.toList a1) >>
-  assertEqualUpToEpsList "" eqEpsilon (OS.toList e2) (OS.toList a2) >>
-  assertEqualUpToEpsList "" eqEpsilon (OS.toList e3) (OS.toList a3) >>
-  assertEqualUpToEpsList "" eqEpsilon (OS.toList e4) (OS.toList a4)
 
 assertEqualUpToEpsVF :: OS.Shape sh => Double -> OS.Array sh Double -> OS.Array sh Double -> Assertion
 assertEqualUpToEpsVF _eps r1 u1 =  -- TODO

--- a/test/common/TestSingleGradient.hs
+++ b/test/common/TestSingleGradient.hs
@@ -762,11 +762,11 @@ instance (ADModeAndNum d r, OS.Shape sh, KnownNat n1, KnownNat n2)
 -- * assertEqualUpToEps hacks (#65)
 
 assertEqualUpToEpsS :: (OS.Shape sh1, OS.Shape sh2, OS.Shape sh3, OS.Shape sh4)
-                     => forall a . (Fractional a, Ord a, Show a, OS.Unbox a, HasCallStack)
-                     => a
-                     -> (OS.Array sh1 a, OS.Array sh2 a, OS.Array sh3 a, OS.Array sh4 a)
-                     -> (OS.Array sh1 a, OS.Array sh2 a, OS.Array sh3 a, OS.Array sh4 a)
-                     -> Assertion
+                    => forall a . (Fractional a, Ord a, Show a, OS.Unbox a, HasCallStack)
+                    => a
+                    -> (OS.Array sh1 a, OS.Array sh2 a, OS.Array sh3 a, OS.Array sh4 a)
+                    -> (OS.Array sh1 a, OS.Array sh2 a, OS.Array sh3 a, OS.Array sh4 a)
+                    -> Assertion
 assertEqualUpToEpsS eqEpsilon (e1, e2, e3, e4) (a1, a2, a3, a4) =
   assertEqualUpToEpsList "" eqEpsilon (OS.toList e1) (OS.toList a1) >>
   assertEqualUpToEpsList "" eqEpsilon (OS.toList e2) (OS.toList a2) >>

--- a/test/common/TestSingleGradient.hs
+++ b/test/common/TestSingleGradient.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE ConstraintKinds, DataKinds, FlexibleInstances,
-             FunctionalDependencies, MultiParamTypeClasses, RankNTypes,
-             TypeFamilies #-}
+             FunctionalDependencies, RankNTypes,
+             TypeFamilies, TypeOperators #-}
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise #-}
 module TestSingleGradient (testTrees, finalCounter) where
@@ -516,7 +516,7 @@ fooS MkSN MkSN MkSN MkSN (x1, x2, x3, x4) =
 
 testFooS :: Assertion
 testFooS =
-  assertEqualUpToEpsilon @Double @((OS.Array '[1] Double), (OS.Array '[5] Double), (OS.Array '[3] Double), (OS.Array '[4] Double))
+  assertEqualUpToEpsilon @Double @(OS.Array '[1] Double, OS.Array '[5] Double, OS.Array '[3] Double, OS.Array '[4] Double)
     (1e-12 :: Double)
     (rev (fooS (MkSN @1) (MkSN @5) (MkSN @3) (MkSN @4))
           ( OS.fromList [1.1]

--- a/test/common/TestSingleGradient.hs
+++ b/test/common/TestSingleGradient.hs
@@ -761,10 +761,19 @@ instance (ADModeAndNum d r, OS.Shape sh, KnownNat n1, KnownNat n2)
 
 -- * assertEqualUpToEps hacks (#65)
 
--- A hack: the normal assertEqualUpToEps should work here. And AssertClose should work for shaped and untyped tensors.
-assertEqualUpToEpsS :: (OS.Shape sh1, OS.Shape sh2, OS.Shape sh3, OS.Shape sh4) => Double -> (OS.Array sh1 Double, OS.Array sh2 Double, OS.Array sh3 Double, OS.Array sh4 Double) -> (OS.Array sh1 Double, OS.Array sh2 Double, OS.Array sh3 Double, OS.Array sh4 Double) -> Assertion
-assertEqualUpToEpsS _eps (r1, r2, r3, r4) (u1, u2, u3, u4) =  -- TODO: use the _eps instead of the default one
-  OS.toList r1 @?~ OS.toList u1 >> OS.toList r2 @?~ OS.toList u2 >> OS.toList r3 @?~ OS.toList u3 >> OS.toList r4 @?~ OS.toList u4
+assertEqualUpToEpsS :: forall a sh1 sh2 sh3 sh4 . (Fractional a, Ord a, Show a, OS.Unbox a,
+                                                   OS.Shape sh1, OS.Shape sh2, OS.Shape sh3, OS.Shape sh4,
+                                                   HasCallStack)
+                     => String
+                     -> a
+                     -> (OS.Array sh1 a, OS.Array sh2 a, OS.Array sh3 a, OS.Array sh4 a)
+                     -> (OS.Array sh1 a, OS.Array sh2 a, OS.Array sh3 a, OS.Array sh4 a)
+                     -> Assertion
+assertEqualUpToEpsS preface eqEpsilon (e1, e2, e3, e4) (a1, a2, a3, a4) =
+  assertEqualUpToEpsList preface eqEpsilon (OS.toList e1) (OS.toList a1) >>
+  assertEqualUpToEpsList preface eqEpsilon (OS.toList e2) (OS.toList a2) >>
+  assertEqualUpToEpsList preface eqEpsilon (OS.toList e3) (OS.toList a3) >>
+  assertEqualUpToEpsList preface eqEpsilon (OS.toList e4) (OS.toList a4)
 
 assertEqualUpToEpsVF :: OS.Shape sh => Double -> OS.Array sh Double -> OS.Array sh Double -> Assertion
 assertEqualUpToEpsVF _eps r1 u1 =  -- TODO

--- a/test/common/TestSingleGradient.hs
+++ b/test/common/TestSingleGradient.hs
@@ -560,7 +560,7 @@ bar_3_75 = value (ravelFromListS . barS (MkSN @3) (MkSN @75))
 
 testBarV :: Assertion
 testBarV =
-  assertEqualUpToEpsilon @'[2, 3, 337] (1e-12 :: Double)
+  assertEqualUpToEpsilon @Double @(OS.Array '[2, 3, 337] Double) (1e-12 :: Double)
     (bar_3_75
        ( 1.1
        , OS.constant 17.3  -- TODO: create more interesting test data

--- a/test/common/TestSingleGradient.hs
+++ b/test/common/TestSingleGradient.hs
@@ -560,7 +560,7 @@ bar_3_75 = value (ravelFromListS . barS (MkSN @3) (MkSN @75))
 
 testBarV :: Assertion
 testBarV =
-  assertEqualUpToEpsShape1 @'[2, 3, 337] "testBarV" (1e-12 :: Double)
+  assertEqualUpToEpsilon @'[2, 3, 337] (1e-12 :: Double)
     (bar_3_75
        ( 1.1
        , OS.constant 17.3  -- TODO: create more interesting test data

--- a/test/common/TestSingleGradient.hs
+++ b/test/common/TestSingleGradient.hs
@@ -761,19 +761,10 @@ instance (ADModeAndNum d r, OS.Shape sh, KnownNat n1, KnownNat n2)
 
 -- * assertEqualUpToEps hacks (#65)
 
-assertEqualUpToEpsS :: forall a sh1 sh2 sh3 sh4 . (Fractional a, Ord a, Show a, OS.Unbox a,
-                                                   OS.Shape sh1, OS.Shape sh2, OS.Shape sh3, OS.Shape sh4,
-                                                   HasCallStack)
-                     => String
-                     -> a
-                     -> (OS.Array sh1 a, OS.Array sh2 a, OS.Array sh3 a, OS.Array sh4 a)
-                     -> (OS.Array sh1 a, OS.Array sh2 a, OS.Array sh3 a, OS.Array sh4 a)
-                     -> Assertion
-assertEqualUpToEpsS preface eqEpsilon (e1, e2, e3, e4) (a1, a2, a3, a4) =
-  assertEqualUpToEpsList preface eqEpsilon (OS.toList e1) (OS.toList a1) >>
-  assertEqualUpToEpsList preface eqEpsilon (OS.toList e2) (OS.toList a2) >>
-  assertEqualUpToEpsList preface eqEpsilon (OS.toList e3) (OS.toList a3) >>
-  assertEqualUpToEpsList preface eqEpsilon (OS.toList e4) (OS.toList a4)
+-- A hack: the normal assertEqualUpToEps should work here. And AssertClose should work for shaped and untyped tensors.
+assertEqualUpToEpsS :: (OS.Shape sh1, OS.Shape sh2, OS.Shape sh3, OS.Shape sh4) => Double -> (OS.Array sh1 Double, OS.Array sh2 Double, OS.Array sh3 Double, OS.Array sh4 Double) -> (OS.Array sh1 Double, OS.Array sh2 Double, OS.Array sh3 Double, OS.Array sh4 Double) -> Assertion
+assertEqualUpToEpsS _eps (r1, r2, r3, r4) (u1, u2, u3, u4) =  -- TODO: use the _eps instead of the default one
+  OS.toList r1 @?~ OS.toList u1 >> OS.toList r2 @?~ OS.toList u2 >> OS.toList r3 @?~ OS.toList u3 >> OS.toList r4 @?~ OS.toList u4
 
 assertEqualUpToEpsVF :: OS.Shape sh => Double -> OS.Array sh Double -> OS.Array sh Double -> Assertion
 assertEqualUpToEpsVF _eps r1 u1 =  -- TODO

--- a/test/common/TestSingleGradient.hs
+++ b/test/common/TestSingleGradient.hs
@@ -424,8 +424,8 @@ foo (x,y,z) =
 
 testFoo :: Assertion
 testFoo =
-  assertEqualUpToEps3 "testFoo" (1e-10 :: Double)
-    (rev foo (1.1, 2.2, 3.3))
+  assertEqualUpToEpsilon (1e-10 :: Double)
+    (rev foo (1.1, 2.2, 3.3) :: (Double,Double,Double))
     (2.4396285219055063, -1.953374825727421, 0.9654825811012627)
 
 bar :: RealFloat a => (a,a,a) -> a
@@ -435,8 +435,8 @@ bar (x,y,z) =
 
 testBar :: Assertion
 testBar =
-  assertEqualUpToEps3 "testBar" (1e-9 :: Double)
-    (rev bar (1.1, 2.2, 3.3))
+  assertEqualUpToEpsilon (1e-9 :: Double)
+    (rev bar (1.1, 2.2, 3.3) :: (Double,Double,Double))
     (6.221706565357043, -12.856908977773593, 6.043601532156671)
 
 -- A check if gradient computation is re-entrant.
@@ -464,8 +464,8 @@ fooConstant = foo (7, 8, 9)
 
 testBaz :: Assertion
 testBaz =
-  assertEqualUpToEps3 "testBaz" (1e-9 :: Double)
-    (rev baz (1.1, 2.2, 3.3))
+  assertEqualUpToEpsilon (1e-9 :: Double)
+    (rev baz (1.1, 2.2, 3.3) :: (Double,Double,Double))
     (0, -5219.20995030263, 2782.276274462047)
 
 -- If terms are numbered and @z@ is, wrongly, decorated with number 0,
@@ -480,8 +480,8 @@ testBaz =
 -- is likely to fail in less naive implementations, as well.
 testBazRenumbered :: Assertion
 testBazRenumbered =
-  assertEqualUpToEps3 "testBazRenumbered" (1e-9 :: Double)
-    (rev (\(x,y,z) -> z + baz (x,y,z)) (1.1, 2.2, 3.3))
+  assertEqualUpToEpsilon (1e-9 :: Double)
+    (rev (\(x,y,z) -> z + baz (x,y,z)) (1.1, 2.2, 3.3) :: (Double,Double,Double))
     (0, -5219.20995030263, 2783.276274462047)
 
 -- A dual-number and list-based version of a function that goes
@@ -494,8 +494,8 @@ fooD _ = error "wrong number of arguments"
 
 testFooD :: Assertion
 testFooD =
-  assertEqualUpToEpsList "testFooD" (1e-10 :: Double)
-    (rev fooD [1.1, 2.2, 3.3])
+  assertEqualUpToEpsilon (1e-10 :: Double)
+    (rev fooD [1.1, 2.2, 3.3] :: [Double])
     [2.4396285219055063, -1.953374825727421, 0.9654825811012627]
 
 -- A dual-number version of a function that goes from three rank one
@@ -588,7 +588,7 @@ bar_vjp_3_75 = fwd (head . barS (MkSN @3) (MkSN @75))
 
 testBarF :: Assertion
 testBarF =
-  assertEqualUpToEpsShape1 "testBarF" (1e-7 :: Double)
+  assertEqualUpToEpsilon (1e-7 :: Double)
     (bar_vjp_3_75
        ( 1.1
        , OS.constant 17.3  -- TODO: create more interesting test data

--- a/test/common/TestSingleGradient.hs
+++ b/test/common/TestSingleGradient.hs
@@ -761,10 +761,17 @@ instance (ADModeAndNum d r, OS.Shape sh, KnownNat n1, KnownNat n2)
 
 -- * assertEqualUpToEps hacks (#65)
 
--- A hack: the normal assertEqualUpToEps should work here. And AssertClose should work for shaped and untyped tensors.
-assertEqualUpToEpsS :: (OS.Shape sh1, OS.Shape sh2, OS.Shape sh3, OS.Shape sh4) => Double -> (OS.Array sh1 Double, OS.Array sh2 Double, OS.Array sh3 Double, OS.Array sh4 Double) -> (OS.Array sh1 Double, OS.Array sh2 Double, OS.Array sh3 Double, OS.Array sh4 Double) -> Assertion
-assertEqualUpToEpsS _eps (r1, r2, r3, r4) (u1, u2, u3, u4) =  -- TODO: use the _eps instead of the default one
-  OS.toList r1 @?~ OS.toList u1 >> OS.toList r2 @?~ OS.toList u2 >> OS.toList r3 @?~ OS.toList u3 >> OS.toList r4 @?~ OS.toList u4
+assertEqualUpToEpsS :: (OS.Shape sh1, OS.Shape sh2, OS.Shape sh3, OS.Shape sh4)
+                     => forall a . (Fractional a, Ord a, Show a, OS.Unbox a, HasCallStack)
+                     => a
+                     -> (OS.Array sh1 a, OS.Array sh2 a, OS.Array sh3 a, OS.Array sh4 a)
+                     -> (OS.Array sh1 a, OS.Array sh2 a, OS.Array sh3 a, OS.Array sh4 a)
+                     -> Assertion
+assertEqualUpToEpsS eqEpsilon (e1, e2, e3, e4) (a1, a2, a3, a4) =
+  assertEqualUpToEpsList "" eqEpsilon (OS.toList e1) (OS.toList a1) >>
+  assertEqualUpToEpsList "" eqEpsilon (OS.toList e2) (OS.toList a2) >>
+  assertEqualUpToEpsList "" eqEpsilon (OS.toList e3) (OS.toList a3) >>
+  assertEqualUpToEpsList "" eqEpsilon (OS.toList e4) (OS.toList a4)
 
 assertEqualUpToEpsVF :: OS.Shape sh => Double -> OS.Array sh Double -> OS.Array sh Double -> Assertion
 assertEqualUpToEpsVF _eps r1 u1 =  -- TODO

--- a/test/common/TestSingleGradient.hs
+++ b/test/common/TestSingleGradient.hs
@@ -516,7 +516,7 @@ fooS MkSN MkSN MkSN MkSN (x1, x2, x3, x4) =
 
 testFooS :: Assertion
 testFooS =
-  assertEqualUpToEpsS @'[1] @'[5] @'[3] @'[4] "testFooS" (1e-10 :: Double)
+  assertEqualUpToEpsShape4 @'[1] @'[5] @'[3] @'[4] "testFooS" (1e-10 :: Double)
     (rev (fooS (MkSN @1) (MkSN @5) (MkSN @3) (MkSN @4))
           ( OS.fromList [1.1]
           , OS.fromList [2.2, 2.3, 7.2, 7.3, 7.4]
@@ -560,7 +560,7 @@ bar_3_75 = value (ravelFromListS . barS (MkSN @3) (MkSN @75))
 
 testBarV :: Assertion
 testBarV =
-  assertEqualUpToEpsS1 @'[2, 3, 337] "testBarV" (1e-12 :: Double)
+  assertEqualUpToEpsShape1 @'[2, 3, 337] "testBarV" (1e-12 :: Double)
     (bar_3_75
        ( 1.1
        , OS.constant 17.3  -- TODO: create more interesting test data
@@ -588,7 +588,7 @@ bar_vjp_3_75 = fwd (head . barS (MkSN @3) (MkSN @75))
 
 testBarF :: Assertion
 testBarF =
-  assertEqualUpToEpsS1 "testBarF" (1e-7 :: Double)
+  assertEqualUpToEpsShape1 "testBarF" (1e-7 :: Double)
     (bar_vjp_3_75
        ( 1.1
        , OS.constant 17.3  -- TODO: create more interesting test data

--- a/test/common/TestSingleGradient.hs
+++ b/test/common/TestSingleGradient.hs
@@ -761,14 +761,6 @@ instance (ADModeAndNum d r, OS.Shape sh, KnownNat n1, KnownNat n2)
 
 -- * assertEqualUpToEps hacks (#65)
 
-assertEqualUpToEps :: Double -> (Double, Double, Double) -> (Double, Double, Double) -> Assertion
-assertEqualUpToEps _eps (r1, r2, r3) (u1, u2, u3) =  -- TODO: use the _eps instead of the default one
-  r1 @?~ u1 >> r2 @?~ u2 >> r3 @?~ u3
-
-assertEqualUpToEpsD :: Double -> [Double] -> [Double] -> Assertion
-assertEqualUpToEpsD _eps l1 l2 =  -- TODO
-  l1 @?~ l2
-
 -- A hack: the normal assertEqualUpToEps should work here. And AssertClose should work for shaped and untyped tensors.
 assertEqualUpToEpsS :: (OS.Shape sh1, OS.Shape sh2, OS.Shape sh3, OS.Shape sh4) => Double -> (OS.Array sh1 Double, OS.Array sh2 Double, OS.Array sh3 Double, OS.Array sh4 Double) -> (OS.Array sh1 Double, OS.Array sh2 Double, OS.Array sh3 Double, OS.Array sh4 Double) -> Assertion
 assertEqualUpToEpsS _eps (r1, r2, r3, r4) (u1, u2, u3, u4) =  -- TODO: use the _eps instead of the default one

--- a/test/common/TestSingleGradient.hs
+++ b/test/common/TestSingleGradient.hs
@@ -516,7 +516,8 @@ fooS MkSN MkSN MkSN MkSN (x1, x2, x3, x4) =
 
 testFooS :: Assertion
 testFooS =
-  assertEqualUpToEpsShape4 @'[1] @'[5] @'[3] @'[4] "testFooS" (1e-10 :: Double)
+  assertEqualUpToEpsilon @Double @((OS.Array '[1] Double), (OS.Array '[5] Double), (OS.Array '[3] Double), (OS.Array '[4] Double))
+    (1e-12 :: Double)
     (rev (fooS (MkSN @1) (MkSN @5) (MkSN @3) (MkSN @4))
           ( OS.fromList [1.1]
           , OS.fromList [2.2, 2.3, 7.2, 7.3, 7.4]

--- a/test/common/TestSingleGradient.hs
+++ b/test/common/TestSingleGradient.hs
@@ -560,7 +560,7 @@ bar_3_75 = value (ravelFromListS . barS (MkSN @3) (MkSN @75))
 
 testBarV :: Assertion
 testBarV =
-  assertEqualUpToEpsVF @'[2, 3, 337] (1e-12 :: Double)
+  assertEqualUpToEpsS1 @'[2, 3, 337] "testBarV" (1e-12 :: Double)
     (bar_3_75
        ( 1.1
        , OS.constant 17.3  -- TODO: create more interesting test data
@@ -588,7 +588,7 @@ bar_vjp_3_75 = fwd (head . barS (MkSN @3) (MkSN @75))
 
 testBarF :: Assertion
 testBarF =
-  assertEqualUpToEpsVF (1e-7 :: Double)
+  assertEqualUpToEpsS1 "testBarF" (1e-7 :: Double)
     (bar_vjp_3_75
        ( 1.1
        , OS.constant 17.3  -- TODO: create more interesting test data
@@ -760,10 +760,6 @@ instance (ADModeAndNum d r, OS.Shape sh, KnownNat n1, KnownNat n2)
 
 
 -- * assertEqualUpToEps hacks (#65)
-
-assertEqualUpToEpsVF :: OS.Shape sh => Double -> OS.Array sh Double -> OS.Array sh Double -> Assertion
-assertEqualUpToEpsVF _eps r1 u1 =  -- TODO
-  OS.toList r1 @?~ OS.toList u1
 
 assertEqualUpToEpsR
   :: OS.Shape sh


### PR DESCRIPTION
Implements fp-equality testing with the error margin explicitly passed as a parameter from the caller. For example:

```haskell
testFoo :: Assertion
testFoo =
  assertEqualUpToEpsilon (1e-10 :: Double)
    (rev foo (1.1, 2.2, 3.3) :: (Double,Double,Double))
    (2.4396285219055063, -1.953374825727421, 0.9654825811012627)
```

This enables us to specify different error margins for different comparisons. If you want to keep it simple, you can still rely on the default error margin specified on the command line using `--eq-epsilon`. In that case, you can use the binary `@?~` operator:

```haskell
res @?~ ([3.5e-44,3.5e-44],5.0 :: Float)
```

This also improves error messages in accordance with #70 .

Fixes #65 #70 