### PR TITLE
Use less Internal imports from ox-arrays

### DIFF
--- a/src/HordeAd/Core/AstEnv.hs
+++ b/src/HordeAd/Core/AstEnv.hs
@@ -32,7 +32,7 @@ import GHC.TypeLits (Nat)
 import Text.Show (showListWith)
 import Type.Reflection (typeRep)
 
-import Data.Array.Mixed.Shape qualified as X
+import Data.Array.Nested (Rank)
 
 import HordeAd.Core.Ast
 import HordeAd.Core.HVector
@@ -128,7 +128,7 @@ extendEnvD vd@(AstDynamicVarName @ty @r @sh varId, d) !env = case d of
     , Just Refl <- sameShape @sh3 @sh
     , Just Refl <- testEquality (typeRep @r) (typeRep @r3) ->
       withListSh (Proxy @sh) $ \sh4 ->
-        extendEnv @ranked @_ @(TKR r (X.Rank sh)) (mkAstVarName varId) (rzero sh4) env
+        extendEnv @ranked @_ @(TKR r (Rank sh)) (mkAstVarName varId) (rzero sh4) env
   DynamicShapedDummy @r3 @sh3 _ _
     | Just Refl <- testEquality (typeRep @ty) (typeRep @[Nat])
     , Just Refl <- sameShape @sh3 @sh

--- a/src/HordeAd/Core/AstFreshId.hs
+++ b/src/HordeAd/Core/AstFreshId.hs
@@ -26,7 +26,7 @@ import Data.Vector.Generic qualified as V
 import GHC.TypeLits (KnownNat, Nat)
 import System.IO.Unsafe (unsafePerformIO)
 
-import Data.Array.Mixed.Shape qualified as X
+import Data.Array.Nested (Rank)
 
 import HordeAd.Core.Ast
 import HordeAd.Core.HVector
@@ -271,9 +271,9 @@ funToAstRevIO ftk | Dict <- lemTensorKindOfF ftk = do
           f i (DynamicRankedDummy @r @sh _ _)
             | Dict <- lemKnownNatRank (knownShS @sh) = do
               return
-                ( DynamicRanked @r @(X.Rank sh)
+                ( DynamicRanked @r @(Rank sh)
                                 (AstGeneric $ AstProjectR astVarPrimal i)
-                , DynamicRanked @r @(X.Rank sh)
+                , DynamicRanked @r @(Rank sh)
                                 (AstGeneric $ AstProjectR astVar i) )
           f i (DynamicShapedDummy @r @sh _ _) = do
             return
@@ -332,11 +332,11 @@ funToAstFwdIO ftk | Dict <- lemTensorKindOfF ftk = do
           f i (DynamicRankedDummy @r @sh _ _)
             | Dict <- lemKnownNatRank (knownShS @sh) = do
               return
-                ( DynamicRanked @r @(X.Rank sh)
+                ( DynamicRanked @r @(Rank sh)
                                 (AstGeneric $ AstProjectR astVarPrimalD i)
-                , DynamicRanked @r @(X.Rank sh)
+                , DynamicRanked @r @(Rank sh)
                                 (AstGeneric $ AstProjectR astVarPrimal i)
-                , DynamicRanked @r @(X.Rank sh)
+                , DynamicRanked @r @(Rank sh)
                                 (AstGeneric $ AstProjectR astVar i) )
           f i (DynamicShapedDummy @r @sh _ _) = do
             return

--- a/src/HordeAd/Core/DualNumber.hs
+++ b/src/HordeAd/Core/DualNumber.hs
@@ -25,7 +25,7 @@ import Data.Vector.Generic qualified as V
 import GHC.TypeLits (KnownNat, sameNat, type (+))
 import Type.Reflection (typeRep)
 
-import Data.Array.Mixed.Types qualified as X
+import Data.Array.Nested (type (++))
 
 import HordeAd.Core.Delta
 import HordeAd.Core.HVector
@@ -258,8 +258,8 @@ instance ( RankedTensor ranked, ShareTensor ranked
 indexPrimalS :: ( ShapedTensor shaped, ShareTensor (RankedOf shaped)
                 , ProductTensor (RankedOf shaped)
                 , GoodScalar r, KnownShS sh1, KnownShS sh2
-                , KnownShS (sh1 X.++ sh2) )
-             => ADVal shaped r (sh1 X.++ sh2) -> IndexSh shaped sh1
+                , KnownShS (sh1 ++ sh2) )
+             => ADVal shaped r (sh1 ++ sh2) -> IndexSh shaped sh1
              -> ADVal shaped r sh2
 indexPrimalS (D u u') ix = dD (sindex u ix) (DeltaS $ IndexS (unDeltaS u') ix)
 

--- a/src/HordeAd/Core/HVector.hs
+++ b/src/HordeAd/Core/HVector.hs
@@ -34,8 +34,7 @@ import Data.Vector.Generic qualified as V
 import GHC.TypeLits (KnownNat, type (+))
 import Type.Reflection (typeRep)
 
-import Data.Array.Mixed.Types qualified as X
-import Data.Array.Nested (ShR (..))
+import Data.Array.Nested (ShR (..), type (++))
 
 import HordeAd.Core.Types
 import HordeAd.Internal.OrthotopeOrphanInstances ()
@@ -376,8 +375,8 @@ index1HVectorF :: ( shaped ~ ShapedOf ranked
                    => ranked r (m + n) -> IndexOf ranked m -> ranked r n)
                -> (forall r sh1 sh2.
                    ( GoodScalar r, KnownShS sh1, KnownShS sh2
-                   , KnownShS (sh1 X.++ sh2) )
-                   => shaped r (sh1 X.++ sh2) -> ShapedList.IndexSh shaped sh1
+                   , KnownShS (sh1 ++ sh2) )
+                   => shaped r (sh1 ++ sh2) -> ShapedList.IndexSh shaped sh1
                    -> shaped r sh2)
                -> HVector ranked -> IntOf ranked -> HVector ranked
 {-# INLINE index1HVectorF #-}
@@ -394,8 +393,8 @@ index1DynamicF :: ( shaped ~ ShapedOf ranked
                    => ranked r (m + n) -> IndexOf ranked m -> ranked r n)
                -> (forall r sh1 sh2.
                    ( GoodScalar r, KnownShS sh1, KnownShS sh2
-                   , KnownShS (sh1 X.++ sh2) )
-                   => shaped r (sh1 X.++ sh2) -> ShapedList.IndexSh shaped sh1
+                   , KnownShS (sh1 ++ sh2) )
+                   => shaped r (sh1 ++ sh2) -> ShapedList.IndexSh shaped sh1
                    -> shaped r sh2)
                -> DynamicTensor ranked -> IntOf ranked -> DynamicTensor ranked
 {-# INLINE index1DynamicF #-}

--- a/src/HordeAd/Core/TensorAst.hs
+++ b/src/HordeAd/Core/TensorAst.hs
@@ -27,7 +27,7 @@ import Data.Vector.Generic qualified as V
 import GHC.TypeLits (KnownNat, Nat)
 import Unsafe.Coerce (unsafeCoerce)
 
-import Data.Array.Mixed.Shape qualified as X
+import Data.Array.Nested (Rank)
 
 import HordeAd.Core.Adaptor
 import HordeAd.Core.Ast
@@ -338,7 +338,7 @@ instance TermValue (DynamicTensor (AstGeneric AstMethodLet FullSpan)) where
   fromValue = \case
     DynamicRanked t -> DynamicRanked $ AstGeneric $ fromPrimal $ AstConst $ runFlipR t
     DynamicShaped @_ @sh t ->
-      gcastWith (unsafeCoerce Refl :: Sh.Rank sh :~: X.Rank sh) $
+      gcastWith (unsafeCoerce Refl :: Sh.Rank sh :~: Rank sh) $
       DynamicShaped @_ @sh $ AstGenericS $ fromPrimal $ AstConstS $ runFlipS t
     DynamicRankedDummy p1 p2 -> DynamicRankedDummy p1 p2
     DynamicShapedDummy p1 p2 -> DynamicShapedDummy p1 p2

--- a/src/HordeAd/Core/TensorConcrete.hs
+++ b/src/HordeAd/Core/TensorConcrete.hs
@@ -20,8 +20,8 @@ import Data.Vector.Generic qualified as V
 import GHC.TypeLits (KnownNat)
 import System.Random
 
-import Data.Array.Mixed.Shape qualified as X
 import Data.Array.Nested qualified as Nested
+import Data.Array.Nested (Rank)
 
 import HordeAd.Core.Adaptor
 import HordeAd.Core.Delta
@@ -246,7 +246,7 @@ instance ShapedTensor OSArray where
   sfromIntegral = FlipS . tfromIntegralS . runFlipS
   sconst = FlipS
   sfromR :: forall r sh. (GoodScalar r, KnownShS sh)
-         => ORArray r (X.Rank sh) -> OSArray r sh
+         => ORArray r (Rank sh) -> OSArray r sh
   sfromR = FlipS . flip Nested.rcastToShaped knownShS . runFlipR
 
   sscaleByScalar s v =
@@ -448,7 +448,7 @@ instance (GoodScalar r, KnownShS sh)
 
 instance GoodScalar r
          => ForgetShape (OSArray r sh) where
-  type NoShape (OSArray r sh) = ORArray r (X.Rank sh)  -- key case
+  type NoShape (OSArray r sh) = ORArray r (Rank sh)  -- key case
   forgetShape = FlipR . Nested.stoRanked . runFlipS
 
 instance (KnownShS sh, GoodScalar r, Fractional r, Random r)

--- a/src/HordeAd/Core/Types.hs
+++ b/src/HordeAd/Core/Types.hs
@@ -43,12 +43,10 @@ import Numeric.LinearAlgebra (Numeric, Vector)
 import Type.Reflection (TypeRep, Typeable, typeRep)
 import Unsafe.Coerce (unsafeCoerce)
 
-import Data.Array.Mixed.Internal.Arith qualified as Nested.Internal.Arith
 import Data.Array.Mixed.Permutation qualified as Permutation
-import Data.Array.Mixed.Shape qualified as X
 import Data.Array.Mixed.Types (Dict (..))
 import Data.Array.Nested
-  (IxS (..), KnownShS (..), ListS (..), ShR (..), ShS (..))
+  (IxS (..), KnownShS (..), ListS (..), ShR (..), ShS (..), Rank)
 import Data.Array.Nested qualified as Nested
 import Data.Array.Nested.Internal.Shape (shsToList)
 
@@ -111,13 +109,13 @@ sameShape = if shapeT @sh1 == shapeT @sh2
             else Nothing
 
 matchingRank :: forall sh1 n2. (KnownShS sh1, KnownNat n2)
-             => Maybe (X.Rank sh1 :~: n2)
+             => Maybe (Rank sh1 :~: n2)
 matchingRank =
   if length (shapeT @sh1) == valueOf @n2
-  then Just (unsafeCoerce Refl :: X.Rank sh1 :~: n2)
+  then Just (unsafeCoerce Refl :: Rank sh1 :~: n2)
   else Nothing
 
-lemKnownNatRank :: ShS sh -> Dict KnownNat (X.Rank sh)
+lemKnownNatRank :: ShS sh -> Dict KnownNat (Rank sh)
 lemKnownNatRank ZSS = Dict
 lemKnownNatRank (_ :$$ sh) | Dict <- lemKnownNatRank sh = Dict
 
@@ -246,7 +244,7 @@ type family HasSingletonDict (y :: ty) where
   HasSingletonDict sh = KnownShS sh
 
 type Differentiable r =
-  (RealFloat r, Nested.Internal.Arith.FloatElt r)
+  (RealFloat r, Nested.FloatElt r)
 
 -- We white-list all types on which we permit differentiation (e.g., SGD)
 -- to work. This is for technical typing purposes and imposes updates

--- a/src/HordeAd/External/CommonRankedOps.hs
+++ b/src/HordeAd/External/CommonRankedOps.hs
@@ -17,7 +17,7 @@ import Data.Proxy (Proxy (Proxy))
 import Data.Type.Equality ((:~:) (Refl))
 import GHC.TypeLits (KnownNat, sameNat)
 
-import Data.Array.Nested.Internal.Ranked qualified as Nested.Internal
+import Data.Array.Nested qualified as Nested
 
 import Data.Int (Int64)
 import HordeAd.Core.TensorClass
@@ -67,7 +67,7 @@ rfromIndex1 :: forall n r ranked.
                , GoodScalar r, RankedOf (PrimalOf ranked) ~ PrimalOf ranked )
             => IndexOf ranked n -> ranked r 1
 rfromIndex1 = case sameNat (Proxy @n) (Proxy @0) of
-  Just Refl -> const $ rconst $ Nested.Internal.rfromListPrimLinear (0 :$: ZSR) []
+  Just Refl -> const $ rconst $ Nested.rfromListPrimLinear (0 :$: ZSR) []
   _ -> rfromIntegral . rconstant . rfromList . NonEmpty.fromList . indexToList
 
 rint64FromIndex1 :: forall n ranked.
@@ -76,7 +76,7 @@ rint64FromIndex1 :: forall n ranked.
                     , RankedOf (PrimalOf ranked) ~ PrimalOf ranked )
                  => IndexOf ranked n -> ranked Int64 1
 rint64FromIndex1 = case sameNat (Proxy @n) (Proxy @0) of
-  Just Refl -> const $ rconst $ Nested.Internal.rfromListPrimLinear (0 :$: ZSR) []
+  Just Refl -> const $ rconst $ Nested.rfromListPrimLinear (0 :$: ZSR) []
   _ -> rconstant . rfromList . NonEmpty.fromList . indexToList
 
 rint64ToIndex1 :: forall n ranked.

--- a/src/HordeAd/Util/SizedList.hs
+++ b/src/HordeAd/Util/SizedList.hs
@@ -44,7 +44,6 @@ import GHC.Exts (IsList (..))
 import GHC.TypeLits (KnownNat, SomeNat (..), sameNat, someNatVal, type (+))
 import Unsafe.Coerce (unsafeCoerce)
 
-import Data.Array.Mixed.Shape qualified as X
 import Data.Array.Nested
   ( IxR (..)
   , ListR (..)
@@ -53,6 +52,7 @@ import Data.Array.Nested
   , pattern (:::)
   , pattern ZIR
   , pattern ZR
+  , Rank
   )
 
 import HordeAd.Core.Types
@@ -348,14 +348,14 @@ withListShape shList f =
 withListSh
   :: KnownShS sh
   => Proxy sh
-  -> (forall n. (KnownNat n, X.Rank sh ~ n)
+  -> (forall n. (KnownNat n, Rank sh ~ n)
       => IShR n -> a)
   -> a
 withListSh (Proxy @sh) f =
   let shList = shapeT @sh
   in case someNatVal $ toInteger (length shList) of
     Just (SomeNat @n _) ->
-      gcastWith (unsafeCoerce Refl :: X.Rank sh :~: n) $
+      gcastWith (unsafeCoerce Refl :: Rank sh :~: n) $
       f $ listToShape @n shList
     _ -> error "withListSh: impossible someNatVal error"
 

--- a/test/simplified/TestAdaptorSimplified.hs
+++ b/test/simplified/TestAdaptorSimplified.hs
@@ -18,10 +18,8 @@ import GHC.TypeLits (KnownNat)
 import Test.Tasty
 import Test.Tasty.HUnit hiding (assert)
 
-import Data.Array.Mixed.Shape qualified as X
 import Data.Array.Nested qualified as Nested
-import Data.Array.Nested.Internal.Ranked qualified as Nested.Internal
-import Data.Array.Nested.Internal.Shaped qualified as Nested.Internal
+import Data.Array.Nested (Rank)
 
 import HordeAd
 import HordeAd.Core.AstEnv
@@ -191,7 +189,7 @@ testZeroZ =
 testZeroS :: Assertion
 testZeroS =
   assertEqualUpToEpsilon 1e-9
-    (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [])
+    (sconst $ Nested.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [])
     (crev (let f :: ADVal OSArray Double '[0, 2, 4, 0, 1]
                  -> ADVal OSArray Double '[0, 2, 4, 0, 1]
                f = const (srepl 3)
@@ -200,7 +198,7 @@ testZeroS =
 testCFwdZeroS :: Assertion
 testCFwdZeroS =
   assertEqualUpToEpsilon 1e-9
-    (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [])
+    (sconst $ Nested.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [])
     (cfwd (let f :: ADVal OSArray Double '[0, 2, 4, 0, 1]
                  -> ADVal OSArray Double '[0, 2, 4, 0, 1]
                f = const (srepl 3)
@@ -209,7 +207,7 @@ testCFwdZeroS =
 testFwdZeroS :: Assertion
 testFwdZeroS =
   assertEqualUpToEpsilon 1e-9
-    (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [])
+    (sconst $ Nested.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [])
     (fwd (let f :: AstShaped FullSpan Double '[0, 2, 4, 0, 1]
                 -> AstShaped FullSpan Double '[0, 2, 4, 0, 1]
               f = const (srepl 3)
@@ -218,7 +216,7 @@ testFwdZeroS =
 testZero2S :: Assertion
 testZero2S =
   assertEqualUpToEpsilon 1e-9
-    (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[] knownShS [1])
+    (sconst $ Nested.sfromListPrimLinear @_ @'[] knownShS [1])
     (crev @_ @(TKS Double '[])
           (let f :: a -> a
                f = id
@@ -227,7 +225,7 @@ testZero2S =
 testCFwdZero2S :: Assertion
 testCFwdZero2S =
   assertEqualUpToEpsilon 1e-9
-    (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[] knownShS [41])
+    (sconst $ Nested.sfromListPrimLinear @_ @'[] knownShS [41])
     (cfwd @_ @(TKS Double '[])
           (let f :: a -> a
                f = id
@@ -236,7 +234,7 @@ testCFwdZero2S =
 testFwdZero2S :: Assertion
 testFwdZero2S =
   assertEqualUpToEpsilon 1e-9
-    (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[] knownShS [41])
+    (sconst $ Nested.sfromListPrimLinear @_ @'[] knownShS [41])
     (fwd @_ @(TKS Double '[])
           (let f :: a -> a
                f = id
@@ -245,25 +243,25 @@ testFwdZero2S =
 testZero3S :: Assertion
 testZero3S =
   assertEqualUpToEpsilon 1e-9
-    (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[33, 2] knownShS (replicate 66 3.6174114266850617))
+    (sconst $ Nested.sfromListPrimLinear @_ @'[33, 2] knownShS (replicate 66 3.6174114266850617))
     (crev (\x -> barF @(ADVal OSArray Double '[33, 2]) (x, x)) (srepl 1))
 
 testCFwdZero3S :: Assertion
 testCFwdZero3S =
   assertEqualUpToEpsilon 1e-9
-    (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[33, 2] knownShS (replicate 66 3.9791525693535674))
+    (sconst $ Nested.sfromListPrimLinear @_ @'[33, 2] knownShS (replicate 66 3.9791525693535674))
     (cfwd (\x -> barF @(ADVal OSArray Double '[33, 2]) (x, x)) (srepl 1) (srepl 1.1))
 
 testFwdZero3S :: Assertion
 testFwdZero3S =
   assertEqualUpToEpsilon 1e-9
-    (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[33, 2] knownShS (replicate 66 3.9791525693535674))
+    (sconst $ Nested.sfromListPrimLinear @_ @'[33, 2] knownShS (replicate 66 3.9791525693535674))
     (fwd (\x -> barF @(AstShaped FullSpan Double '[33, 2]) (x, x)) (srepl 1) (srepl 1.1))
 
 testZero4S :: Assertion
 testZero4S =
   assertEqualUpToEpsilon 1e-9
-    (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[] knownShS [0])
+    (sconst $ Nested.sfromListPrimLinear @_ @'[] knownShS [0])
     (rev @(AstShaped FullSpan Double '[]) @(TKS Double '[])
          (let f = const (srepl 3)
           in f) (srepl 42))
@@ -271,7 +269,7 @@ testZero4S =
 testZero5S :: Assertion
 testZero5S =
   assertEqualUpToEpsilon 1e-9
-    (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[44] knownShS (replicate 44 1))
+    (sconst $ Nested.sfromListPrimLinear @_ @'[44] knownShS (replicate 44 1))
     (rev (let f :: a -> a
               f = id
           in f @(AstShaped FullSpan Double '[44])) (srepl 42))
@@ -279,14 +277,14 @@ testZero5S =
 testZero6S :: Assertion
 testZero6S =
   assertEqualUpToEpsilon 1e-9
-    (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[2, 2, 2, 2, 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, 2, 2, 2, 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,11,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,111,1,1,1,1, 2, 2, 2, 2] knownShS (replicate (product ([2, 2, 2, 2, 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, 2, 2, 2, 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,11,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,111,1,1,1,1, 2, 2, 2, 2] :: [Int])) 3.6174114266850617))
+    (sconst $ Nested.sfromListPrimLinear @_ @'[2, 2, 2, 2, 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, 2, 2, 2, 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,11,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,111,1,1,1,1, 2, 2, 2, 2] knownShS (replicate (product ([2, 2, 2, 2, 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, 2, 2, 2, 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,11,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,111,1,1,1,1, 2, 2, 2, 2] :: [Int])) 3.6174114266850617))
     (rev @_ @(TKS Double '[2, 2, 2, 2, 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, 2, 2, 2, 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,11,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,111,1,1,1,1, 2, 2, 2, 2])
          (\x -> barF (x, x)) (srepl 1))
 
 testZero7S :: Assertion
 testZero7S =
   assertEqualUpToEpsilon 1e-10
-    (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[] knownShS [0])
+    (sconst $ Nested.sfromListPrimLinear @_ @'[] knownShS [0])
     (rev (const 3 :: AstShaped FullSpan Double '[] -> AstRanked FullSpan Double 0) (srepl 42))
 
 testZero8 :: Assertion
@@ -308,7 +306,7 @@ testZero9S =
 testCFwdZero9S :: Assertion
 testCFwdZero9S =
   assertEqualUpToEpsilon 1e-9
-    (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [])
+    (sconst $ Nested.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [])
     (cfwd (let f :: ADVal ORArray Double 5
                  -> ADVal OSArray Double '[0, 2, 4, 0, 1]
                f = const (srepl 3)
@@ -318,7 +316,7 @@ testCFwdZero9S =
 testFwdZero9S :: Assertion
 testFwdZero9S =
   assertEqualUpToEpsilon 1e-9
-    (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [])
+    (sconst $ Nested.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [])
     (fwd (let f :: AstRanked FullSpan Double 5
                 -> AstShaped FullSpan Double '[0, 2, 4, 0, 1]
               f = const (srepl 3)
@@ -329,7 +327,7 @@ testZero10S :: Assertion
 testZero10S =
   assertEqualUpToEpsilon 1e-9
     ( rfromList0N [0, 2, 4, 0, 1] []
-    , sconst $ Nested.Internal.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [] )
+    , sconst $ Nested.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [] )
     (crev (let f = const (srepl 3) . snd
            in f :: ( ADVal ORArray Double 5
                    , ADVal OSArray Double '[0, 2, 4, 0, 1] )
@@ -339,34 +337,34 @@ testZero10S =
 testCFwdZero10S :: Assertion
 testCFwdZero10S =
   assertEqualUpToEpsilon 1e-9
-    (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [])
+    (sconst $ Nested.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [])
     (cfwd (let f = const (srepl 3) . snd
            in f :: ( ADVal ORArray Double 5
                    , ADVal OSArray Double '[0, 2, 4, 0, 1] )
                    -> ADVal OSArray Double '[0, 2, 4, 0, 1])
           ( rfromList0N [0, 2, 4, 0, 1] []
-          , sconst $ Nested.Internal.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [] )
+          , sconst $ Nested.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [] )
           ( rfromList0N [0, 2, 4, 0, 1] []
-          , sconst $ Nested.Internal.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [] ))
+          , sconst $ Nested.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [] ))
 
 testFwdZero10S :: Assertion
 testFwdZero10S =
   assertEqualUpToEpsilon 1e-9
-    (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [])
+    (sconst $ Nested.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [])
     (fwd  (let f = const (srepl 3) . snd
            in f :: ( AstRanked FullSpan Double 5
                    , AstShaped FullSpan Double '[0, 2, 4, 0, 1] )
                    -> AstShaped FullSpan Double '[0, 2, 4, 0, 1])
           ( rfromList0N [0, 2, 4, 0, 1] []
-          , sconst $ Nested.Internal.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [] )
+          , sconst $ Nested.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [] )
           ( rfromList0N [0, 2, 4, 0, 1] []
-          , sconst $ Nested.Internal.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [] ))
+          , sconst $ Nested.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [] ))
 
 testZero11S :: Assertion
 testZero11S =
   assertEqualUpToEpsilon 1e-9
     ( rfromList0N [0, 2, 4, 0, 1] []
-    , sconst $ Nested.Internal.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [] )
+    , sconst $ Nested.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [] )
     (crev (let f = const (rreplicate0N [0, 2, 4, 0, 1] 3) . snd
            in f :: ( ADVal ORArray Double 5
                    , ADVal OSArray Double '[0, 2, 4, 0, 1] )
@@ -382,9 +380,9 @@ testCFwdZero11S =
                    , ADVal OSArray Double '[0, 2, 4, 0, 1] )
                    -> ADVal ORArray Double 5)
           ( rfromList0N [0, 2, 4, 0, 1] []
-          , sconst $ Nested.Internal.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [] )
+          , sconst $ Nested.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [] )
           ( rfromList0N [0, 2, 4, 0, 1] []
-          , sconst $ Nested.Internal.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [] ))
+          , sconst $ Nested.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [] ))
 
 testFwdZero11S :: Assertion
 testFwdZero11S =
@@ -395,9 +393,9 @@ testFwdZero11S =
                    , AstShaped FullSpan Double '[0, 2, 4, 0, 1] )
                    -> AstRanked FullSpan Double 5)
           ( rfromList0N [0, 2, 4, 0, 1] []
-          , sconst $ Nested.Internal.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [] )
+          , sconst $ Nested.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [] )
           ( rfromList0N [0, 2, 4, 0, 1] []
-          , sconst $ Nested.Internal.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [] ))
+          , sconst $ Nested.sfromListPrimLinear @_ @'[0, 2, 4, 0, 1] knownShS [] ))
 
 testPiecewiseLinearPP :: Assertion
 testPiecewiseLinearPP = do
@@ -1024,9 +1022,9 @@ testReluSimpler4S = do
       reluT2 (t, r) = reluS (t * sreplicate0N r)
   assertEqualUpToEpsilon 1e-10
     ( sconst
-      $ Nested.Internal.sfromListPrimLinear @_ @'[3, 4] knownShS [7.0,0.0,0.0,7.0,7.0,7.0,7.0,7.0,0.0,0.0,7.0,7.0]
+      $ Nested.sfromListPrimLinear @_ @'[3, 4] knownShS [7.0,0.0,0.0,7.0,7.0,7.0,7.0,7.0,0.0,0.0,7.0,7.0]
     , srepl 57.1 )
-    (rev reluT2 (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[3, 4] knownShS [1.1, -2.2, 0, 4.4, 5.5, 6.6, 7.7, 8.8, -9.9, -10, 11, 12], srepl 7))
+    (rev reluT2 (sconst $ Nested.sfromListPrimLinear @_ @'[3, 4] knownShS [1.1, -2.2, 0, 4.4, 5.5, 6.6, 7.7, 8.8, -9.9, -10, 11, 12], srepl 7))
 
 reluMax :: forall ranked n r. (ADReady ranked, GoodScalar r, KnownNat n)
         => ranked r n -> ranked r n
@@ -1206,8 +1204,8 @@ testMatmul2PPS = do
       (artifactRev, _) =
         revArtifactAdapt
                  True (uncurry smatmul2)
-                 ( sconst $ Nested.Internal.sfromListPrimLinear @_ @'[2,3] knownShS [1 :: Double .. 6]
-                 , sconst $ Nested.Internal.sfromListPrimLinear @_ @'[3,4] knownShS [7 .. 18] )
+                 ( sconst $ Nested.sfromListPrimLinear @_ @'[2,3] knownShS [1 :: Double .. 6]
+                 , sconst $ Nested.sfromListPrimLinear @_ @'[3,4] knownShS [7 .. 18] )
   printArtifactPretty renames artifactRev
     @?= "\\m2 x1 -> tpair (ssum (stranspose (stranspose (sreplicate (tproject2 m1)) * sreplicate m2)), ssum (stranspose (stranspose (sreplicate (tproject1 m1)) * sreplicate m2)))"
   printArtifactPrimalPretty renames artifactRev
@@ -1550,16 +1548,16 @@ testBarReluMax3CFwd =
     (OR.fromList [2, 1, 2] [0.45309153191767404,0.9060427799711201,-2.8186426018387007,40.02498898648793])
     (cfwd @_ @(TKR Double 3)
           barReluMax
-                     (rconst $ Nested.Internal.rfromListPrimLinear (fromList [2, 1, 2]) [1.1, 2, 3, 4.2])
+                     (rconst $ Nested.rfromListPrimLinear (fromList [2, 1, 2]) [1.1, 2, 3, 4.2])
                      (ringestData [2, 1, 2] [0.1, 0.2, 0.3, 0.42]))
 
 reluMaxS :: forall shaped sh r.
-            (ADReadyS shaped, GoodScalar r, KnownShS sh, KnownNat (X.Rank sh))
+            (ADReadyS shaped, GoodScalar r, KnownShS sh, KnownNat (Rank sh))
          => shaped r sh -> shaped r sh
 reluMaxS = smap0N (maxF (srepl 0))
 
 barReluMaxS
-  :: ( ADReadyS shaped, GoodScalar r, KnownShS sh, KnownNat (X.Rank sh)
+  :: ( ADReadyS shaped, GoodScalar r, KnownShS sh, KnownNat (Rank sh)
      , RealFloatF (shaped r sh) )
   => shaped r sh -> shaped r sh
 barReluMaxS x = reluMaxS $ barF (x, reluMaxS x)
@@ -1569,20 +1567,20 @@ barReluMaxS x = reluMaxS $ barF (x, reluMaxS x)
 testBarReluMax3FwdS :: Assertion
 testBarReluMax3FwdS =
   assertEqualUpToEpsilon 1e-10
-    (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[2, 1, 2] knownShS [0.45309153191767404,0.9060427799711201,-2.8186426018387007,40.02498898648793])
+    (sconst $ Nested.sfromListPrimLinear @_ @'[2, 1, 2] knownShS [0.45309153191767404,0.9060427799711201,-2.8186426018387007,40.02498898648793])
     (fwd @_ @(TKS Double '[2, 1, 2])
          barReluMaxS
-         (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[2, 1, 2] knownShS [1.1, 2, 3, 4.2])
-         (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[2, 1, 2] knownShS [0.1, 0.2, 0.3, 0.42]))
+         (sconst $ Nested.sfromListPrimLinear @_ @'[2, 1, 2] knownShS [1.1, 2, 3, 4.2])
+         (sconst $ Nested.sfromListPrimLinear @_ @'[2, 1, 2] knownShS [0.1, 0.2, 0.3, 0.42]))
 
 testBarReluMax3FwdFrom :: Assertion
 testBarReluMax3FwdFrom =
   assertEqualUpToEpsilon 1e-10
-    (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[2, 1, 2] knownShS [0.45309153191767404,0.9060427799711201,-2.8186426018387007,40.02498898648793])
+    (sconst $ Nested.sfromListPrimLinear @_ @'[2, 1, 2] knownShS [0.45309153191767404,0.9060427799711201,-2.8186426018387007,40.02498898648793])
     (fwd @_ @(TKS Double '[2, 1, 2])
          (sfromR . barReluMax . rfromS)
-         (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[2, 1, 2] knownShS [1.1, 2, 3, 4.2])
-         (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[2, 1, 2] knownShS [0.1, 0.2, 0.3, 0.42]))
+         (sconst $ Nested.sfromListPrimLinear @_ @'[2, 1, 2] knownShS [1.1, 2, 3, 4.2])
+         (sconst $ Nested.sfromListPrimLinear @_ @'[2, 1, 2] knownShS [0.1, 0.2, 0.3, 0.42]))
 
 testBarReluMax3FwdR :: Assertion
 testBarReluMax3FwdR =
@@ -1905,7 +1903,7 @@ emptyArgs _t =
        -- these two fail and rightly so; TODO: make them fail earlier
  where
   emptyTensor :: ranked r 1
-  emptyTensor = rconst $ Nested.Internal.rfromListPrimLinear (fromList [0]) []
+  emptyTensor = rconst $ Nested.rfromListPrimLinear (fromList [0]) []
 
 testEmptyArgs0 :: Assertion
 testEmptyArgs0 =

--- a/test/simplified/TestConvSimplified.hs
+++ b/test/simplified/TestConvSimplified.hs
@@ -17,7 +17,6 @@ import Test.Tasty
 import Test.Tasty.HUnit hiding (assert)
 
 import Data.Array.Nested qualified as Nested
-import Data.Array.Nested.Internal.Ranked qualified as Nested.Internal
 
 import HordeAd
 import HordeAd.Core.AstEnv
@@ -112,12 +111,12 @@ slicezF shOut d ixBase =
 conv2d1
   :: (ADReady ranked, GoodScalar r, Differentiable r)
   => ranked r 4 -> ranked r 4
-conv2d1 = conv2d $ rconst $ Nested.Internal.rfromListPrimLinear (fromList [1, 1, 1, 1]) [-0.2]
+conv2d1 = conv2d $ rconst $ Nested.rfromListPrimLinear (fromList [1, 1, 1, 1]) [-0.2]
 
 conv2dA
   :: (ADReady ranked, GoodScalar r, Differentiable r)
   => ranked r 4 -> ranked r 4
-conv2dA = conv2d $ rconst $ Nested.Internal.rfromListPrimLinear (fromList [1, 2, 1, 1]) [-0.2, 25.0003]
+conv2dA = conv2d $ rconst $ Nested.rfromListPrimLinear (fromList [1, 2, 1, 1]) [-0.2, 25.0003]
 
 conv2dB
   :: (ADReady ranked, GoodScalar r, Differentiable r)
@@ -167,13 +166,13 @@ testKonstG0LittleA =
 conv2d1Laborious
   :: (ADReady ranked, GoodScalar r, Differentiable r)
   => ranked r 4 -> ranked r 4
-conv2d1Laborious = conv2dUnpadded $ rconst $ Nested.Internal.rfromListPrimLinear (fromList [1, 1, 1, 1]) [-0.2]
+conv2d1Laborious = conv2dUnpadded $ rconst $ Nested.rfromListPrimLinear (fromList [1, 1, 1, 1]) [-0.2]
 
 conv2dALaborious
   :: (ADReady ranked, GoodScalar r, Differentiable r)
   => ranked r 4 -> ranked r 4
 conv2dALaborious =
-  conv2dUnpadded $ rconst $ Nested.Internal.rfromListPrimLinear (fromList [1, 2, 1, 1]) [-0.2, 25.0003]
+  conv2dUnpadded $ rconst $ Nested.rfromListPrimLinear (fromList [1, 2, 1, 1]) [-0.2, 25.0003]
 
 conv2dBLaborious
   :: (ADReady ranked, GoodScalar r, Differentiable r)

--- a/test/simplified/TestGatherSimplified.hs
+++ b/test/simplified/TestGatherSimplified.hs
@@ -14,7 +14,6 @@ import Test.Tasty
 import Test.Tasty.HUnit hiding (assert)
 
 import Data.Array.Nested qualified as Nested
-import Data.Array.Nested.Internal.Ranked qualified as Nested.Internal
 
 import HordeAd
 import HordeAd.Core.AstFreshId (resetVarCounter)
@@ -429,7 +428,7 @@ testGatherTransposeBuild335 =
     (OR.fromList [2, 1] [1,1])
     (rev' @Double @3
           (\t ->
-             rreplicate 2 t * rtranspose [2,0,1] (rreplicate 2 (rreplicate 1 (rfromIntegral @_ @Int64 (rconst $ Nested.Internal.rfromListPrimLinear (fromList [2]) [0, 1])))))
+             rreplicate 2 t * rtranspose [2,0,1] (rreplicate 2 (rreplicate 1 (rfromIntegral @_ @Int64 (rconst $ Nested.rfromListPrimLinear (fromList [2]) [0, 1])))))
          (FlipR $ OR.fromList [2, 1] [1,2]))
 
 testGatherTransposeBuild336 :: Assertion

--- a/test/simplified/TestHighRankSimplified.hs
+++ b/test/simplified/TestHighRankSimplified.hs
@@ -11,10 +11,8 @@ import GHC.TypeLits (KnownNat, type (+), type (-), type (<=))
 import Test.Tasty
 import Test.Tasty.HUnit hiding (assert)
 
-import Data.Array.Mixed.Shape qualified as X
 import Data.Array.Nested qualified as Nested
-import Data.Array.Nested.Internal.Shape qualified as Nested.Internal.Shape
-import Data.Array.Nested.Internal.Shaped qualified as Nested.Internal
+import Data.Array.Nested (Rank)
 
 import HordeAd
 import HordeAd.Core.AstFreshId (resetVarCounter)
@@ -111,7 +109,7 @@ _testBar =
 _testBarS :: Assertion
 _testBarS =
   assertEqualUpToEpsilon 1e-5
-    (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[3, 1, 2, 2, 1, 2, 2] knownShS [304.13867,914.9335,823.0187,1464.4688,5264.3306,1790.0055,1535.4309,3541.6572,304.13867,914.9335,823.0187,1464.4688,6632.4355,6047.113,1535.4309,1346.6815,45.92141,6.4903135,5.5406737,1.4242969,6.4903135,1.1458766,4.6446533,2.3550234,88.783676,27.467598,125.27507,18.177452,647.1915,0.3878851,2177.6152,786.1792,6.4903135,6.4903135,6.4903135,6.4903135,2.3550234,2.3550234,2.3550234,2.3550234,21.783596,2.3550234,2.3550234,2.3550234,21.783596,21.783596,21.783596,21.783596], sconst $ Nested.Internal.sfromListPrimLinear @_ @'[3, 1, 2, 2, 1, 2, 2] knownShS [-5728.7617,24965.113,32825.07,-63505.953,-42592.203,145994.88,-500082.5,-202480.06,-5728.7617,24965.113,32825.07,-63505.953,49494.473,-2446.7632,-500082.5,-125885.58,-43.092484,-1.9601002,-98.97709,2.1931143,-1.9601002,1.8243169,-4.0434446,-1.5266153,2020.9731,-538.0603,-84.28137,62.963814,-34986.996,-9.917454,135.30023,17741.998,-1.9601002,-1.9601002,-1.9601002,-1.9601002,-1.5266153,-1.5266153,-1.5266153,-1.5266153,-4029.1775,-1.5266153,-1.5266153,-1.5266153,-4029.1775,-4029.1775,-4029.1775,-4029.1775])
+    (sconst $ Nested.sfromListPrimLinear @_ @'[3, 1, 2, 2, 1, 2, 2] knownShS [304.13867,914.9335,823.0187,1464.4688,5264.3306,1790.0055,1535.4309,3541.6572,304.13867,914.9335,823.0187,1464.4688,6632.4355,6047.113,1535.4309,1346.6815,45.92141,6.4903135,5.5406737,1.4242969,6.4903135,1.1458766,4.6446533,2.3550234,88.783676,27.467598,125.27507,18.177452,647.1915,0.3878851,2177.6152,786.1792,6.4903135,6.4903135,6.4903135,6.4903135,2.3550234,2.3550234,2.3550234,2.3550234,21.783596,2.3550234,2.3550234,2.3550234,21.783596,21.783596,21.783596,21.783596], sconst $ Nested.sfromListPrimLinear @_ @'[3, 1, 2, 2, 1, 2, 2] knownShS [-5728.7617,24965.113,32825.07,-63505.953,-42592.203,145994.88,-500082.5,-202480.06,-5728.7617,24965.113,32825.07,-63505.953,49494.473,-2446.7632,-500082.5,-125885.58,-43.092484,-1.9601002,-98.97709,2.1931143,-1.9601002,1.8243169,-4.0434446,-1.5266153,2020.9731,-538.0603,-84.28137,62.963814,-34986.996,-9.917454,135.30023,17741.998,-1.9601002,-1.9601002,-1.9601002,-1.9601002,-1.5266153,-1.5266153,-1.5266153,-1.5266153,-4029.1775,-1.5266153,-1.5266153,-1.5266153,-4029.1775,-4029.1775,-4029.1775,-4029.1775])
     (crev (barF @(ADVal OSArray Float '[3, 1, 2, 2, 1, 2, 2])) (sfromR t48, sfromR t48))
 
 -- A dual-number and list-based version of a function that goes
@@ -212,8 +210,8 @@ testFooBuild25 =
 
 fooBuild2S
   :: forall k sh ranked r shaped.
-     (ADReady ranked, GoodScalar r, KnownNat k, Floating (shaped r sh), RealFloat r, shaped ~ ShapedOf ranked, KnownShS sh, KnownNat (Nested.Internal.Shape.Product (k : sh)))
-  => shaped r (k : sh) -> ranked r (1 + X.Rank sh)
+     (ADReady ranked, GoodScalar r, KnownNat k, Floating (shaped r sh), RealFloat r, shaped ~ ShapedOf ranked, KnownShS sh, KnownNat (Nested.Product (k : sh)))
+  => shaped r (k : sh) -> ranked r (1 + Rank sh)
 fooBuild2S v = rfromS $
   sbuild1 @_ @_ @2 $ \ix ->
     ifF (sfromR ix - (sprimalPart . sfloor) (ssum0 @shaped @r @[5,12,11,9,4]

--- a/test/simplified/TestRevFwdFold.hs
+++ b/test/simplified/TestRevFwdFold.hs
@@ -17,10 +17,8 @@ import GHC.TypeLits (KnownNat, type (+))
 import Test.Tasty
 import Test.Tasty.HUnit hiding (assert)
 
-import Data.Array.Mixed.Shape qualified as X
 import Data.Array.Nested qualified as Nested
-import Data.Array.Nested.Internal.Ranked qualified as Nested.Internal
-import Data.Array.Nested.Internal.Shaped qualified as Nested.Internal
+import Data.Array.Nested (Rank)
 
 import HordeAd
 import HordeAd.Core.AstFreshId (resetVarCounter)
@@ -1111,7 +1109,7 @@ testSin0Scan1Rev2PP1 = do
   resetVarCounter
   let a1 = rrev1 @(AstRanked PrimalSpan) @Double @0 @1
                  (\x0 -> rscan (\x a -> sin x - a) x0
-                           (rconst (Nested.Internal.rfromListPrimLinear @Double @1 (fromList [2]) [5, 7]))) (rscalar 1.1)
+                           (rconst (Nested.rfromListPrimLinear @Double @1 (fromList [2]) [5, 7]))) (rscalar 1.1)
   printAstPretty IM.empty (simplifyInlineAst a1)
     @?= "let v3 = rconst (rfromListLinear [2] [5.0,7.0]) ; v6 = rconst (rfromListLinear [3] [1.0,1.0,1.0]) in v6 ! [0] + tproject1 (dmapAccumRDer (SNat @2) <lambda> <lambda> <lambda> 0.0 (tpair (rslice 1 2 v6, tpair (tproject1 (tproject2 (dmapAccumLDer (SNat @2) <lambda> <lambda> <lambda> 1.1 v3)), v3))))"
 
@@ -1122,7 +1120,7 @@ testSin0Scan1Rev2PPA = do
         revArtifactAdapt
                  True
                  (\x0 -> rscan (\x a -> sin x - a) x0
-                           (rconst (Nested.Internal.rfromListPrimLinear @Double @1 (fromList [2]) [5, 7])))
+                           (rconst (Nested.rfromListPrimLinear @Double @1 (fromList [2]) [5, 7])))
                  (rscalar 1.1)
   printArtifactPretty IM.empty (simplifyArtifact art)
     @?= "\\v5 x1 -> let v2 = rconst (rfromListLinear [2] [5.0,7.0]) in v5 ! [0] + tproject1 (dmapAccumRDer (SNat @2) <lambda> <lambda> <lambda> 0.0 (tpair (rslice 1 2 v5, tpair (tproject1 (tproject2 (dmapAccumLDer (SNat @2) <lambda> <lambda> <lambda> x1 v2)), v2))))"
@@ -1143,7 +1141,7 @@ testSin0Scan1Rev2 = do
   assertEqualUpToEpsilon' 1e-10
     (OR.fromList [] [1.1961317861865948] :: OR.Array 0 Double)
     (rev' (\x0 -> rscan (\x a -> sin x - a) x0
-                    (rconst (Nested.Internal.rfromListPrimLinear @Double @1 (fromList [2]) [5, 7]))) 1.1)
+                    (rconst (Nested.rfromListPrimLinear @Double @1 (fromList [2]) [5, 7]))) 1.1)
 
 testSin0Scan1Rev2ForComparison :: Assertion
 testSin0Scan1Rev2ForComparison = do
@@ -2230,7 +2228,7 @@ testSin0rmapAccumRD01SN531b0 = do
                           (HVectorPseudoTensor $ dmkHVector $ V.fromList [ DynamicShaped @Double @'[]
                                         $ sfromR x0 ])
                           (HVectorPseudoTensor $ dmkHVector $ V.fromList [ DynamicRanked @Double @1
-                                        $ rconst $ Nested.Internal.rfromListPrimLinear (fromList [0]) [] ]))))
+                                        $ rconst $ Nested.rfromListPrimLinear (fromList [0]) [] ]))))
                         $ \ !d -> rfromD $ d V.! 0
            in f) 1.1)
 
@@ -2279,7 +2277,7 @@ testSin0rmapAccumRD01SN531bR = do
                            in h)
                           (HVectorPseudoTensor $ dmkHVector $ V.fromList [ DynamicRanked x0 ])
                           (HVectorPseudoTensor $ dmkHVector $ V.fromList [ DynamicRanked @Double @1
-                                        $ rconst $ Nested.Internal.rfromListPrimLinear (fromList [1]) [0] ]))))
+                                        $ rconst $ Nested.rfromListPrimLinear (fromList [1]) [0] ]))))
                         $ \ !d -> rfromD $ d V.! 0
            in f) 1.1)
 
@@ -2304,7 +2302,7 @@ testSin0rmapAccumRD01SN531b0PP = do
                           (HVectorPseudoTensor $ dmkHVector $ V.fromList [ DynamicShaped @Double @'[]
                                         $ sfromD (x0 V.! 0) ])
                           (HVectorPseudoTensor $ dmkHVector $ V.fromList [ DynamicRanked @Double @1
-                                        $ rconst $ Nested.Internal.rfromListPrimLinear (fromList [0]) [] ]))))
+                                        $ rconst $ Nested.rfromListPrimLinear (fromList [0]) [] ]))))
                         $ \ !d -> rfromD $ d V.! 0
       g :: forall g. (LetTensor g (ShapedOf g), ProductTensor g)
         => HVector g -> HVectorOf g
@@ -2395,7 +2393,7 @@ testSin0rmapAccumRD01SN531bRPP = do
                            in h)
                           (HVectorPseudoTensor $ dmkHVector x0)
                           (HVectorPseudoTensor $ dmkHVector $ V.fromList [ DynamicRanked @Double @1
-                                        $ rconst $ Nested.Internal.rfromListPrimLinear (fromList [1]) [0] ]))))
+                                        $ rconst $ Nested.rfromListPrimLinear (fromList [1]) [0] ]))))
                         $ \ !d -> rfromD $ d V.! 0
       g :: forall g. (LetTensor g (ShapedOf g), ProductTensor g)
         => HVector g -> HVectorOf g
@@ -2429,7 +2427,7 @@ testSin0rmapAccumRD01SN531b0PPj = do
                                $ sfromIntegral (sconstant (sfromR (i + j)))
                                  + sfromD (x0 V.! 0) ])
                           (HVectorPseudoTensor $ dmkHVector $ V.fromList [ DynamicRanked @Double @1
-                                        $ rconst $ Nested.Internal.rfromListPrimLinear (fromList [0]) [] ]))))
+                                        $ rconst $ Nested.rfromListPrimLinear (fromList [0]) [] ]))))
                         $ \ !d -> rfromD $ d V.! 0
       g :: forall g. (LetTensor g (ShapedOf g), ProductTensor g)
         => HVector g -> HVectorOf g
@@ -2497,7 +2495,7 @@ testSin0rmapAccumRD01SN531bRPPj = do
                                $ rfromIntegral (rconstant (i + j))
                                  + rfromD (x0 V.! 0) ])
                           (HVectorPseudoTensor $ dmkHVector $ V.fromList [ DynamicRanked @Double @1
-                                        $ rconst $ Nested.Internal.rfromListPrimLinear (fromList [1]) [0] ]))))
+                                        $ rconst $ Nested.rfromListPrimLinear (fromList [1]) [0] ]))))
                         $ \ !d -> rfromD $ d V.! 0
       g :: forall g. (LetTensor g (ShapedOf g), ProductTensor g)
         => HVector g -> HVectorOf g
@@ -2765,7 +2763,7 @@ testSin0rmapAccumRD01SN56 = do
 testSin0rmapAccumRD01SN57 :: Assertion
 testSin0rmapAccumRD01SN57 = do
   assertEqualUpToEpsilon 1e-10
-    (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[2] knownShS [0.4989557335681351,1.1])
+    (sconst $ Nested.sfromListPrimLinear @_ @'[2] knownShS [0.4989557335681351,1.1])
     (cfwd (let f :: forall f. ADReadyS f => f Double '[] -> f Double '[2]
                f x0 = (sfromD . (V.! 1))
                       $ dunHVector $ productToVectorOf
@@ -2791,7 +2789,7 @@ testSin0rmapAccumRD01SN57 = do
 testSin0rmapAccumRD01SN58 :: Assertion
 testSin0rmapAccumRD01SN58 = do
   assertEqualUpToEpsilon 1e-10
-    (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[5] knownShS [0,0,0,0,1.1])
+    (sconst $ Nested.sfromListPrimLinear @_ @'[5] knownShS [0,0,0,0,1.1])
     (cfwd (let f :: forall f. ADReadyS f => f Double '[] -> f Double '[5]
                f x0 = (sfromD . (V.! 1))
                       $ dunHVector $ productToVectorOf
@@ -2817,7 +2815,7 @@ testSin0rmapAccumRD01SN58 = do
 testSin0rmapAccumRD01SN59 :: Assertion
 testSin0rmapAccumRD01SN59 = do
   assertEqualUpToEpsilon 1e-10
-    (sconst $ Nested.Internal.sfromListPrimLinear @_ @'[1] knownShS [1.1])
+    (sconst $ Nested.sfromListPrimLinear @_ @'[1] knownShS [1.1])
     (cfwd (let f :: forall f. ADReadyS f => f Double '[] -> f Double '[1]
                f x0 = (sfromD . (V.! 1))
                       $ dunHVector $ productToVectorOf
@@ -3236,7 +3234,7 @@ testSin0ScanD1Rev2PP = do
                  (\x0 -> rscanZip (\x a -> sin x - rfromD (a V.! 0))
                          (V.fromList [voidFromSh @Double ZSR])
                          x0 (V.singleton $ DynamicRanked
-                             $ rconst (Nested.Internal.rfromListPrimLinear @Double @1 (fromList [2]) [5, 7]))) (rscalar 1.1)
+                             $ rconst (Nested.rfromListPrimLinear @Double @1 (fromList [2]) [5, 7]))) (rscalar 1.1)
   printAstPretty IM.empty (simplifyInlineAst a1)
     @?= "let v25 = rconst (rfromListLinear [2] [5.0,7.0]) ; v20 = rconst (rfromListLinear [3] [1.0,1.0,1.0]) in rproject (tproject1 (dmapAccumRDer (SNat @2) <lambda> <lambda> <lambda> [0.0] (tpair ([rslice 1 2 v20], tpair (tproject1 (tproject2 (dmapAccumLDer (SNat @2) <lambda> <lambda> <lambda> [1.1] [v25])), [v25]))))) 0 + v20 ! [0]"
 
@@ -3247,7 +3245,7 @@ testSin0ScanDFwd2PP = do
                  (\x0 -> rscanZip (\x a -> sin x - rfromD (a V.! 0))
                          (V.fromList [voidFromSh @Double ZSR])
                          x0 (V.singleton $ DynamicRanked
-                         $ rconst (Nested.Internal.rfromListPrimLinear @Double @1 (fromList [2]) [5, 7]))) (rscalar 1.1)
+                         $ rconst (Nested.rfromListPrimLinear @Double @1 (fromList [2]) [5, 7]))) (rscalar 1.1)
   printAstPretty IM.empty (simplifyInlineAst a1)
     @?= "let v24 = rconst (rfromListLinear [2] [5.0,7.0]) in rappend (rreplicate 1 1.0) (rproject (tproject2 (dmapAccumLDer (SNat @2) <lambda> <lambda> <lambda> [1.0] (tpair ([rreplicate 2 0.0], tpair (tproject1 (tproject2 (dmapAccumLDer (SNat @2) <lambda> <lambda> <lambda> [1.1] [v24])), [v24]))))) 0)"
 
@@ -3259,7 +3257,7 @@ testSin0ScanD1Rev2 = do
        rscanZip (\x a -> sin x - rfromD (a V.! 0))
                 (V.fromList [voidFromShS @Double @'[]])
                 x0 (V.singleton $ DynamicShaped
-                    $ sconst (Nested.Internal.sfromListPrimLinear @Double @'[2, 2] knownShS [5, 7, 3, 4])
+                    $ sconst (Nested.sfromListPrimLinear @Double @'[2, 2] knownShS [5, 7, 3, 4])
                       !$ (k :.$ ZIS) ))
           1.1)
 
@@ -4752,7 +4750,7 @@ testSin0revhFoldZip4R = do
 fFoldS
   :: forall m k rm shm r sh shaped.
      ( KnownNat k, GoodScalar rm, KnownShS shm, GoodScalar r, KnownShS sh
-     , ADReadyS shaped, KnownNat m, X.Rank shm ~ m)
+     , ADReadyS shaped, KnownNat m, Rank shm ~ m)
   => shaped r (1 + k ': sh)
   -> shaped rm (k ': shm)
   -> (forall f. ADReadyS f


### PR DESCRIPTION
I exported some additional things from ox-arrays, and you were using some things from internal modules that were already exported.

https://git.tomsmeding.com/ox-arrays/diff/?h=singletons&id=2a3e58084da47d1dd3b557997e239ded480539a6&id2=48bb58de893bdd28a8bae534bf618fb5790833ca

There are less internal imports from ox-arrays now, but there are still a bunch left. When the decisions of whether to promote something to a public export or not started to become more difficult, I just copped out and stopped the process.

Also CI seems broken?