### PR TITLE
Fix up convolution gradient benchmarks and correctness tests

### DIFF
--- a/bench/ConvVjpBench.hs
+++ b/bench/ConvVjpBench.hs
@@ -9,14 +9,22 @@
 -- in TestConvQuickCheck:
 --
 -- * @S-fullpipe@: @vjp@ per call, i.e., tracing + AD + simplification
---   + interpretation every time (this is what the issue calls Symbolic).
--- * @S-artifact@: producing and simplifying the gradient artifact only.
+--   + interpretation every time (this is what the issue calls Symbolic),
+--   in a @-hoisted@ variant (artifact floated out of the timed loop) and a
+--   @-honest@ variant (artifact rebuilt every call).
+-- * @S-artifact@: building + simplifying the gradient artifact only (the
+--   compilation cost), forced to WHNF (StrictData suffices), as in
+--   mnistTrainBench2VTC in BenchMnistTools.
 -- * @S-exec@: interpreting a pre-computed simplified artifact only.
 -- * @S-exec-raw@: interpreting a pre-computed unsimplified artifact,
 --   to see what simplifyArtifactRev buys at runtime.
 -- * @H-fullpipe@: building + vectorizing + interpreting the handwritten
 --   gradient term per call (what the issue calls HandwrittenVectorized).
 -- * @H-exec@: interpreting the pre-built handwritten gradient term only.
+-- * @H-exec-contracted@: as @H-exec@, but after @simplifyInlineContract@.
+-- * @H-exec-var@: as @H-exec-contracted@, but with the cotangent kept as a
+--   variable (like in the artifact); the apples-to-apples comparison
+--   against @S-exec@.
 --
 -- The @inp-*@ groups run the same variants for the gradient with respect
 -- to the input image (the @sscatter@ path) instead of the kernels, and the
@@ -103,12 +111,14 @@ benchesAt = do
       hTermVarSimplified = simplifyInlineContract hTermVar
       artifactRaw = vjpArtifact f arrK
       artifact = simplifyArtifactRev artifactRaw
-  -- Force the shared terms before benchmarking the exec-only variants.
-  _ <- evaluate (length (printAstSimple hTerm))
-  _ <- evaluate (length (printAstSimple hTermSimplified))
-  _ <- evaluate (length (printAstSimple hTermVarSimplified))
-  _ <- evaluate (length (printArtifactSimple artifact))
-  _ <- evaluate (length (printArtifactSimple artifactRaw))
+  -- Force the shared terms to WHNF (StrictData makes that a full build)
+  -- before benchmarking the exec-only variants. WHNF suffices and avoids the
+  -- string-formatting work of forcing via printArtifactSimple.
+  _ <- evaluate hTerm
+  _ <- evaluate hTermSimplified
+  _ <- evaluate hTermVarSimplified
+  _ <- evaluate artifact
+  _ <- evaluate artifactRaw
   return
     [ -- vjp per call, but with f and arrK fixed and only dt varying.
       -- The artifact does not depend on dt, so full-laziness floats its
@@ -123,9 +133,14 @@ benchesAt = do
         (\a -> forceGrad
                $ vjp (\k -> conv2dSameS k (sconcrete (unConcrete a))) arrK arrB)
         arrA
+      -- Building + simplifying the artifact only (the "compilation" cost),
+      -- forced to WHNF as in mnistTrainBench2VTC (BenchMnistTools): with
+      -- StrictData that suffices to force the build, and unlike forcing via
+      -- printArtifactSimple it does not time string formatting (which grows
+      -- with AST size and dwarfs the actual build). The input is the whnf
+      -- argument so the body depends on it and criterion re-runs it per call.
     , bench "S-artifact" $ whnf
-        (\k -> length $ printArtifactSimple
-             $ simplifyArtifactRev $ vjpArtifact f k) arrK
+        (\k -> simplifyArtifactRev (vjpArtifact f k)) arrK
     , bench "S-exec" $ whnf
         (\dt -> forceGrad
                   (vjpInterpretArtifact artifact arrK dt
@@ -185,11 +200,12 @@ benchesInpAt = do
       hTermVarSimplified = simplifyInlineContract hTermVar
       artifactRaw = vjpArtifact g arrA
       artifact = simplifyArtifactRev artifactRaw
-  _ <- evaluate (length (printAstSimple hTerm))
-  _ <- evaluate (length (printAstSimple hTermSimplified))
-  _ <- evaluate (length (printAstSimple hTermVarSimplified))
-  _ <- evaluate (length (printArtifactSimple artifact))
-  _ <- evaluate (length (printArtifactSimple artifactRaw))
+  -- Force to WHNF (a full build under StrictData) before benchmarking.
+  _ <- evaluate hTerm
+  _ <- evaluate hTermSimplified
+  _ <- evaluate hTermVarSimplified
+  _ <- evaluate artifact
+  _ <- evaluate artifactRaw
   return
     [ bench "S-fullpipe-hoisted" $ whnf
         (\dt -> forceGrad $ vjp g arrA dt) arrB
@@ -197,9 +213,9 @@ benchesInpAt = do
         (\k -> forceGrad
                $ vjp (\a -> conv2dSameS (sconcrete (unConcrete k)) a) arrA arrB)
         arrK
+      -- Artifact build+simplify only, WHNF-forced; see 'benchesAt'.
     , bench "S-artifact" $ whnf
-        (\a -> length $ printArtifactSimple
-             $ simplifyArtifactRev $ vjpArtifact g a) arrA
+        (\a -> simplifyArtifactRev (vjpArtifact g a)) arrA
     , bench "S-exec" $ whnf
         (\dt -> forceGrad
                   (vjpInterpretArtifact artifact arrA dt
@@ -309,12 +325,13 @@ gatherBenches = do
                                          _ -> error "canonS2"))))
                    (\case [c, d] -> [c + d]
                           _ -> error "canonS2"))
-  _ <- evaluate (length (printAstSimple twoS))
-  _ <- evaluate (length (printAstSimple twoH))
-  _ <- evaluate (length (printAstSimple fusedS))
-  _ <- evaluate (length (printAstSimple fusedH))
-  _ <- evaluate (length (printAstSimple canonS))
-  _ <- evaluate (length (printAstSimple canonS2))
+  -- Force to WHNF (a full build under StrictData) before benchmarking.
+  _ <- evaluate twoS
+  _ <- evaluate twoH
+  _ <- evaluate fusedS
+  _ <- evaluate fusedH
+  _ <- evaluate canonS
+  _ <- evaluate canonS2
   return
     [ bench "two-gathers-S-orient" $ whnf
         (\t -> forceGrad $ interpretAstFull emptyEnv t) twoS
@@ -425,10 +442,11 @@ scatterBenches = do
   checkAdjoint "two-scatters-H-orient" gTwoH arrX1 twoScatterH arrY2
   checkAdjoint "fused-scatter-S-orient" gFusedS arrX2 fusedScatterS arrY3
   checkAdjoint "fused-scatter-H-orient" gFusedH arrX2 fusedScatterH arrY4
-  _ <- evaluate (length (printAstSimple twoScatterS))
-  _ <- evaluate (length (printAstSimple twoScatterH))
-  _ <- evaluate (length (printAstSimple fusedScatterS))
-  _ <- evaluate (length (printAstSimple fusedScatterH))
+  -- Force to WHNF (a full build under StrictData) before benchmarking.
+  _ <- evaluate twoScatterS
+  _ <- evaluate twoScatterH
+  _ <- evaluate fusedScatterS
+  _ <- evaluate fusedScatterH
   return
     [ bench "two-scatters-S-orient" $ whnf
         (\t -> forceGrad $ interpretAstFull emptyEnv t) twoScatterS

--- a/test/simplified/TestConvQuickCheck.hs
+++ b/test/simplified/TestConvQuickCheck.hs
@@ -103,76 +103,76 @@ testTrees =
                  (sizedSymbolicPerCall @6)
   , testProperty "conv2dSameVjp Bench dKrn 6 SymbolicAmortized"
                  (sizedSymbolicAmortized @6)
-  , testProperty "conv2dSameVjp Bench dKrn 6 HandwrittenVec"
+  , testProperty "conv2dSameVjp Bench dKrn 6 HandwrittenVectorized"
                  (sizedHandwrittenVectorized @6)
   , testProperty "conv2dSameVjp Bench dKrn 24 SymbolicPerCall"
                  (sizedSymbolicPerCall @24)
   , testProperty "conv2dSameVjp Bench dKrn 24 SymbolicAmortized"
                  (sizedSymbolicAmortized @24)
-  , testProperty "conv2dSameVjp Bench dKrn 24 HandwrittenVec"
+  , testProperty "conv2dSameVjp Bench dKrn 24 HandwrittenVectorized"
                  (sizedHandwrittenVectorized @24)
   , testProperty "conv2dSameVjp Bench dInp 6 SymbolicPerCall"
                  (sizedSymbolicPerCallInp @6)
   , testProperty "conv2dSameVjp Bench dInp 6 SymbolicAmortized"
                  (sizedSymbolicAmortizedInp @6)
-  , testProperty "conv2dSameVjp Bench dInp 6 HandwrittenVec"
+  , testProperty "conv2dSameVjp Bench dInp 6 HandwrittenVectorized"
                  (sizedHandwrittenVectorizedInp @6)
   , testProperty "conv2dSameVjp Bench dInp 24 SymbolicPerCall"
                  (sizedSymbolicPerCallInp @24)
   , testProperty "conv2dSameVjp Bench dInp 24 SymbolicAmortized"
                  (sizedSymbolicAmortizedInp @24)
-  , testProperty "conv2dSameVjp Bench dInp 24 HandwrittenVec"
+  , testProperty "conv2dSameVjp Bench dInp 24 HandwrittenVectorized"
                  (sizedHandwrittenVectorizedInp @24)
   -- Shrinking convolution: input larger than output.
   , testProperty "conv2dShrinkingVjp Bench dKrn 6 SymbolicPerCall"
                  (shrinkingSymbolicPerCall @6)
   , testProperty "conv2dShrinkingVjp Bench dKrn 6 SymbolicAmortized"
                  (shrinkingSymbolicAmortized @6)
-  , testProperty "conv2dShrinkingVjp Bench dKrn 6 HandwrittenVec"
-                 (shrinkingHandwrittenVec @6)
+  , testProperty "conv2dShrinkingVjp Bench dKrn 6 HandwrittenVectorized"
+                 (shrinkingHandwrittenVectorized @6)
   , testProperty "conv2dShrinkingVjp Bench dKrn 24 SymbolicPerCall"
                  (shrinkingSymbolicPerCall @24)
   , testProperty "conv2dShrinkingVjp Bench dKrn 24 SymbolicAmortized"
                  (shrinkingSymbolicAmortized @24)
-  , testProperty "conv2dShrinkingVjp Bench dKrn 24 HandwrittenVec"
-                 (shrinkingHandwrittenVec @24)
+  , testProperty "conv2dShrinkingVjp Bench dKrn 24 HandwrittenVectorized"
+                 (shrinkingHandwrittenVectorized @24)
   , testProperty "conv2dShrinkingVjp Bench dInp 6 SymbolicPerCall"
                  (shrinkingSymbolicPerCallInp @6)
   , testProperty "conv2dShrinkingVjp Bench dInp 6 SymbolicAmortized"
                  (shrinkingSymbolicAmortizedInp @6)
-  , testProperty "conv2dShrinkingVjp Bench dInp 6 HandwrittenVec"
-                 (shrinkingHandwrittenVecInp @6)
+  , testProperty "conv2dShrinkingVjp Bench dInp 6 HandwrittenVectorized"
+                 (shrinkingHandwrittenVectorizedInp @6)
   , testProperty "conv2dShrinkingVjp Bench dInp 24 SymbolicPerCall"
                  (shrinkingSymbolicPerCallInp @24)
   , testProperty "conv2dShrinkingVjp Bench dInp 24 SymbolicAmortized"
                  (shrinkingSymbolicAmortizedInp @24)
-  , testProperty "conv2dShrinkingVjp Bench dInp 24 HandwrittenVec"
-                 (shrinkingHandwrittenVecInp @24)
+  , testProperty "conv2dShrinkingVjp Bench dInp 24 HandwrittenVectorized"
+                 (shrinkingHandwrittenVectorizedInp @24)
   -- Padded convolution: output larger than input.
   , testProperty "conv2dPaddedVjp Bench dKrn 6 SymbolicPerCall"
                  (paddedSymbolicPerCall @6)
   , testProperty "conv2dPaddedVjp Bench dKrn 6 SymbolicAmortized"
                  (paddedSymbolicAmortized @6)
-  , testProperty "conv2dPaddedVjp Bench dKrn 6 HandwrittenVec"
-                 (paddedHandwrittenVec @6)
+  , testProperty "conv2dPaddedVjp Bench dKrn 6 HandwrittenVectorized"
+                 (paddedHandwrittenVectorized @6)
   , testProperty "conv2dPaddedVjp Bench dKrn 24 SymbolicPerCall"
                  (paddedSymbolicPerCall @24)
   , testProperty "conv2dPaddedVjp Bench dKrn 24 SymbolicAmortized"
                  (paddedSymbolicAmortized @24)
-  , testProperty "conv2dPaddedVjp Bench dKrn 24 HandwrittenVec"
-                 (paddedHandwrittenVec @24)
+  , testProperty "conv2dPaddedVjp Bench dKrn 24 HandwrittenVectorized"
+                 (paddedHandwrittenVectorized @24)
   , testProperty "conv2dPaddedVjp Bench dInp 6 SymbolicPerCall"
                  (paddedSymbolicPerCallInp @6)
   , testProperty "conv2dPaddedVjp Bench dInp 6 SymbolicAmortized"
                  (paddedSymbolicAmortizedInp @6)
-  , testProperty "conv2dPaddedVjp Bench dInp 6 HandwrittenVec"
-                 (paddedHandwrittenVecInp @6)
+  , testProperty "conv2dPaddedVjp Bench dInp 6 HandwrittenVectorized"
+                 (paddedHandwrittenVectorizedInp @6)
   , testProperty "conv2dPaddedVjp Bench dInp 24 SymbolicPerCall"
                  (paddedSymbolicPerCallInp @24)
   , testProperty "conv2dPaddedVjp Bench dInp 24 SymbolicAmortized"
                  (paddedSymbolicAmortizedInp @24)
-  , testProperty "conv2dPaddedVjp Bench dInp 24 HandwrittenVec"
-                 (paddedHandwrittenVecInp @24)
+  , testProperty "conv2dPaddedVjp Bench dInp 24 HandwrittenVectorized"
+                 (paddedHandwrittenVectorizedInp @24)
   ]
 
 -- This one is not convolution-related, but it's also QuickCheck.
@@ -1392,8 +1392,8 @@ quickcheck_conv2dSameVjpInpConcrete =
 --   the misleading poor man's benchmark above);
 -- * @SymbolicAmortized@ builds the artifact once (shared across all runs)
 --   and only interprets it per run — the intended usage;
--- * @HandwrittenVec@ is the handwritten gradient vectorized and interpreted
---   per run, for comparison.
+-- * @HandwrittenVectorized@ is the handwritten gradient vectorized and
+--   interpreted per run, for comparison.
 --
 -- At small sizes the build tax roughly doubles the per-call symbolic time
 -- while the amortized cost is competitive with the handwritten one; as the
@@ -1526,12 +1526,15 @@ shrinkingSymbolicAmortized =
                                         (sconcrete (unConcrete arrB))
        in allClose v v 1e-5
 
-shrinkingHandwrittenVec :: forall nAw. (KnownNat nAw, 1 <= nAw) => Property
-shrinkingHandwrittenVec =
+shrinkingHandwrittenVectorized
+  :: forall nAw. (KnownNat nAw, 1 <= nAw) => Property
+shrinkingHandwrittenVectorized =
   property $ \seed0 ->
     let (_, arrA, arrB) = benchDataShrinking @nAw @Double seed0
         v :: Concrete (TKS '[3, 3, 3, 3] Double)
         v = interpretAstFull emptyEnv
+            -- @2 @2 here, not @3 @3 as for Same: the shrinking and padded
+            -- handwritten gradients take nKh1 = nKh - 1, so 2 is a 3x3 kernel.
             $ conv2dShrinking_dKrn @3 @3 @3 @nAw @nAw @2 @2
                                    (sconcrete (unConcrete arrA))
                                    (sconcrete (unConcrete arrB))
@@ -1562,8 +1565,8 @@ shrinkingSymbolicAmortizedInp =
                                         (sconcrete (unConcrete arrB))
        in allClose v v 1e-5
 
-shrinkingHandwrittenVecInp :: forall nAw. KnownNat nAw => Property
-shrinkingHandwrittenVecInp =
+shrinkingHandwrittenVectorizedInp :: forall nAw. KnownNat nAw => Property
+shrinkingHandwrittenVectorizedInp =
   property $ \seed0 ->
     let (arrK, _, arrB) = benchDataShrinking @nAw @Double seed0
         v :: Concrete (TKS '[3, 3, nAw + 2, nAw + 2] Double)
@@ -1613,8 +1616,8 @@ paddedSymbolicAmortized =
                                         (sconcrete (unConcrete arrB))
        in allClose v v 1e-5
 
-paddedHandwrittenVec :: forall nAw. (KnownNat nAw, 1 <= nAw) => Property
-paddedHandwrittenVec =
+paddedHandwrittenVectorized :: forall nAw. (KnownNat nAw, 1 <= nAw) => Property
+paddedHandwrittenVectorized =
   property $ \seed0 ->
     let (_, arrA, arrB) = benchDataPadded @nAw @Double seed0
         v :: Concrete (TKS '[3, 3, 3, 3] Double)
@@ -1649,8 +1652,8 @@ paddedSymbolicAmortizedInp =
                                         (sconcrete (unConcrete arrB))
        in allClose v v 1e-5
 
-paddedHandwrittenVecInp :: forall nAw. KnownNat nAw => Property
-paddedHandwrittenVecInp =
+paddedHandwrittenVectorizedInp :: forall nAw. KnownNat nAw => Property
+paddedHandwrittenVectorizedInp =
   property $ \seed0 ->
     let (arrK, _, arrB) = benchDataPadded @nAw @Double seed0
         v :: Concrete (TKS '[3, 3, nAw, nAw] Double)


### PR DESCRIPTION
Follow-up to #128, fixing a measurement bug in `bench/ConvVjpBench.hs` plus
naming/doc uniformity. Benchmark-only; no library behaviour changes.

## The `S-artifact` fix

`S-artifact` (and the exec-only setup pre-forcing) forced AST/artifact values
with `length . printArtifactSimple`. That **timed pretty-printing, not
building**: the AST has no `NFData` (see `BenchMnistTools`: `-- no NFData for
AST`), so print was the only full-force, and it dwarfed the ~0.5 ms build
(reported up to ~2.8 s). It could also be **CSE-collapsed** — the fixed-input
body is byte-identical to the shared `artifact` binding, so some sizes returned
a cached value (`inp-192` 658 µs vs `inp-96` 2780 ms).

Fix: force to WHNF, as `mnistTrainBench2VTC` does — with `StrictData`, WHNF
fully builds the AST. `S-artifact` is now a stable ~0.5 ms (matching the
`S-fullpipe-honest − S-fullpipe-hoisted` differential), and setup pre-forces via
`evaluate` rather than `length (print …)` (a speedup: all setup runs before
`defaultMain`).

## Uniformity / doc fixups

- Uniform `HandwrittenVectorized` naming for the size-scaled benchmarks
  (functions + all twelve tasty labels), replacing abbreviated `HandwrittenVec`.
- A note on why shrinking/padded gradients take `@2 @2` (`nKh1 = nKh − 1`) vs
  Same's `@3 @3`.
- Completed the `ConvVjpBench` variant list (`H-exec-contracted`/`H-exec-var`).

## Validation

`S-artifact` at 48×48: 23.2 ms → 530 µs, stable across sizes; a back-to-back A/B
leaves the exec variants unchanged within noise; CAFlessTest 670/670.
