### PR TITLE
Improve convolution gradient benchmarks and correctness tests, etc

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -189,12 +189,20 @@ jobs:
       - name: build
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
+      # NB: the `tests` and `benchmarks` steps below are project-specific
+      # additions maintained by hand in this generated file; re-apply them
+      # after `haskell-ci regenerate`.
       - name: tests
         run: |
           $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH minimalTest --test-show-details=direct --test-options='-p "detSquare"'
       - name: benchmarks
         run: |
           $CABAL v2-bench $ARG_COMPILER $ARG_TESTS $ARG_BENCH shortProdForCI
+          # convVjpBench (issue #123 conv/CNN diagnostic) as a fast smoke run:
+          # -n 1 runs every group once, without statistics, catching build and
+          # runtime breakage across the conv2dPreserving, gather/scatter and cnn-*
+          # paths (not a perf tripwire: CI criterion numbers are too noisy).
+          $CABAL v2-bench $ARG_COMPILER $ARG_TESTS $ARG_BENCH convVjpBench --benchmark-options='-n 1'
       - name: cabal check
         run: |
           cd ${PKGDIR_horde_ad} || false

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ cabal.project.local~
 *.swp
 *.swo
 *~
+.claude/

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -9,7 +9,7 @@
 # Specify additional command line arguments
 #
 # - arguments: [--color, --cpp-simple, -XQuasiQuotes]
-- arguments: [--cpp-simple, -XNoStarIsType]
+- arguments: [-XNoStarIsType]
 
 
 # Control which extensions/flags/modules/functions can be used

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,198 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+horde-ad is a Haskell automatic differentiation library (reverse and forward mode) that supports array operations and generation of symbolic derivative programs. It is an early prototype and deliberately not coded defensively: code is expected to fail on cases not covered by current tests, and the fix is to add primitives/tests rather than defensive code.
+
+Upstream stack: the array backend is ox-arrays (maintained by a horde-ad co-author) over orthotope. Mikolaj maintains horde-ad and, while not an orthotope maintainer, has a history of accepted orthotope PRs — equivalent standing when deciding where a fix should land — so performance fixes are planned across the whole horde-ad → ox-arrays → orthotope stack, orthotope changes going in as PRs to its maintainer. Orthotope deliberately contains no mutable code (a pure `Vector v` class API); keep proposals for it pure.
+
+The closing portable-notes section holds the author-generic conventions and the machine-specific session facts — the sandbox's misleading "No such file" errors, phantom dotfiles in `git status`, `git`/`cabal` writes needing to run unsandboxed — skim it before debugging anything environment-related.
+
+## Build and test commands
+
+Development setup (fast builds, optimization off; guarded not to clobber an existing config):
+
+    [ -f cabal.project.local ] ||
+      cp cabal.project.local.development cabal.project.local
+    cabal build
+
+Run `cabal` (like all `git` writes and `gpg`) unsandboxed — `~/.cabal` is read-only under the inner sandbox (sandboxing notes below). A full build takes long: give Bash a generous timeout or run it in the background rather than concluding it hung. Local `cabal haddock` costs ~10 minutes even for a sublibrary (haddock re-runs GHC's front end over the whole library dependency, with the typelits plugins dominating typechecking) — prefer CI's `--haddock-all` step, which runs on every push.
+
+Tests are computation-intensive, so run them with optimization even though the dev config sets `optimization: False` for builds: any timing taken without `--enable-optimization` runs ~8x slower and is **not** comparable to optimized numbers — a mysterious ~8x discrepancy is usually exactly this. Pass the flag on the command line:
+
+    cabal test minimalTest --enable-optimization  # short, no dataset needed
+    cabal test CAFlessTest --enable-optimization  # sequential; doubles as a benchmark
+    cabal test sequentialMnistTest --enable-optimization  # same
+    cabal test parallelTest --enable-optimization 2>/dev/null  # large MNIST tests; stderr redirect keeps interleaved printf tidy
+    cabal test fullTest --enable-optimization  # everything, sequentially
+
+Run a single test with a tasty pattern:
+
+    cabal test CAFlessTest --enable-optimization --test-options='-p "gatherNested1"'
+
+Test suites in `test/` are thin `Main` wrappers combining `testTrees` from modules in `test/simplified/` (the `testCommonLibrary` sublibrary); test tools (`EqEpsilon` for epsilon float comparison via the `--eq-epsilon` tasty option, `CrossTesting`) live in `test/tool/`. MNIST tests read gzipped IDX files from `samplesData/`. CAFlessTest must stay sequential: the AST-variable counter reset is not thread-safe, and some tests check printed ASTs whose numbering varies with execution order.
+
+Benchmarks: `cabal bench shortProdForCI`, `longProdBench`, `shortMnistForCI`, `longMnistBench` (criterion; a sixth target, `realisticMnistBench`, is deliberately `buildable: False` so that plain `cabal bench` terminates in finite time). The `convVjpBench` benchmark (`bench/ConvVjpBench.hs`; not built under the `release` flag) is the [#123](https://github.com/Mikolaj/horde-ad/issues/123) diagnostic: `conv2dPreservingS` kernel- and input-gradient (dKrn/dInp) sweeps at 6–192, the symbolic and handwritten pipelines decomposed into pairwise-comparable `S-*`/`H-*` stage variants, `gather48`/`scatter48` isolating micro-benchmarks, `cnn-*` groups timing a real shaped two-layer CNN gradient, and a `pitfalls` group with the suite's single recorder of each known measurement trap (artifact hoisting, constant-cotangent embedding). It uses only random data (`randomValue`), so it needs no `samplesData` and runs anywhere; `PRINT_TERMS=1` prints the compared gradient programs instead of benchmarking. As the repo's only convolution-performance benchmark (the MNIST bench suites cover only FCNN nets) it outlives [#123](https://github.com/Mikolaj/horde-ad/issues/123): run it, with full criterion statistics, whenever touching conv-relevant code (gather/scatter rewrites in `contractAst`, the interpreter, the ox-arrays gather path) — the CI smoke run collects none. To analyze a run, collect it with `--benchmark-options='--csv FILE'` and check the module haddock's numbered time properties with `python3 tools/check-conv-bench-props.py FILE` (10% tolerance); the haddock classifies whether a failure means a broken measurement, an engine regression, or a legitimately shifted cost model.
+
+CI protects `convVjpBench` twice: the build step compiles *all* benchmarks (`--enable-benchmarks all`) and the benchmarks step smoke-runs the whole suite with `--benchmark-options='-n 1'` — every benchmark once, no statistics, seconds total. That is build-and-runtime smoke protection, not a perf tripwire: CI criterion numbers are too noisy to gate on.
+
+Source checkouts of ox-arrays and orthotope may be present as siblings (`../ox-arrays`, `../orthotope`) — whether a session sees them depends on the wrapper (sandboxing notes below); when hidden they report "No such file", and the released sources can always be unpacked from the cabal store instead (recipe in the build-and-shell-tooling notes). The kernels of interest are `mgenerate`, `Data.Array.Strided.Arith` and the `X.replicate` stride tricks. The `packages: ../ox-arrays` line in `cabal.project.local` is often commented out, in which case builds use the released ox-arrays from the cabal store, not the checkout — check before assuming local edits take effect.
+
+Cabal flags: `with_expensive_assertions` (extra checks), `release` (set for Hackage releases; disables test suites that need unpackaged data), `test_seq` (force parallelTest to run sequentially).
+
+Lint/format: `.hlint.yaml` (its `arguments:` passes `-XNoStarIsType`, mirroring the cabal's `default-extensions` — hlint doesn't read the cabal, and without the flag the seven files importing `GHC.TypeLits (…, type (*))` fail to parse) and `.stylish-haskell.yaml` (stylish-haskell); both tools are on PATH, hlint as a locally compiled v3.10 — earlier binaries mishandled that flag and silently *skipped* those seven files with a parse error, so "hlint-clean" claims from before 2026-07 don't cover them (`--cpp-simple` was dropped from the yaml at the same time: the fixed hlint's default CPP handling parses everything, while `--cpp-simple` itself broke on `Core/Types.hs`). CI (haskell-ci generated) builds and tests with GHC 9.10.3, 9.12.4 and 9.14.1, but its tests step runs only `minimalTest -p "detSquare"` (plus the benchmark smoke runs) — CAFlessTest and the other suites, including every printed-AST test, are validated only by local runs.
+
+Standing checks, for a generic "run checks" request — each with its trigger:
+
+- Always: `python3 tools/check-plan-citations.py DOC` over CLAUDE.md and every draft staged in the repo root; then, for any document edited since it was last verified, passes 2 and 3 of the three-pass discipline (portable notes below — pass 3, the quantified-claims grep, is the one that keeps finding real errors).
+- When Haskell code changed: build, then `minimalTest` and `CAFlessTest` with `--enable-optimization` (the larger suites above when the change warrants), stylish-haskell and hlint on touched files.
+- After a push: CI status via `curl -s "https://api.github.com/repos/Mikolaj/horde-ad/actions/runs?branch=BRANCH&per_page=3"`, reading each run's `head_sha`, `status` and `conclusion` (`gh` is unauthenticated). A green run also validates haddock markup, since the haddock step covers benchmarks and tests.
+- After conv-relevant changes, and after any full `convVjpBench` run: the numbered time properties via `tools/check-conv-bench-props.py` (see the benchmark paragraph above).
+- When a new self-checking assertion or checker tool is born: prove it non-vacuous by deliberately breaking it (portable notes), and record the proof next to it.
+
+## Architecture
+
+The library is organized around a final-tagless style: tensor operations are type classes (chiefly `BaseTensor` in `HordeAd.Core.Ops`) over a `target :: Target` type constructor, indexed by a type-level tensor kind `TK`. Objective functions are written polymorphically in `target` and then instantiated at one of three carriers:
+
+- `Concrete` — plain evaluation on CPU arrays (backed by ox-arrays/orthotope). Defined in `Core/CarriersConcrete.hs`, instances in `Core/OpsConcrete.hs`.
+- `ADVal target` — dual numbers for direct (tape-like) AD, generic over the underlying carrier. `Core/CarriersADVal.hs`, `Core/OpsADVal.hs`.
+- `AstTensor` — symbolic AST terms. `Core/Ast.hs` (grammar), `Core/CarriersAst.hs`, `Core/OpsAst.hs`.
+
+Tensor kinds (`Core/Types.hs`, `Core/TensorKind.hs`): `TKScalar r`, `TKR n r` (ranked: only rank in the type), `TKS sh r` (shaped: full shape in the type), `TKX sh r` (mixed), `TKProduct` (tuples); `TKR2`/`TKS2`/`TKX2` allow nested element kinds. Operation names are prefixed by variant: `r*` ranked, `s*` shaped, `x*` mixed, `t*` kind-polymorphic (`tlet`, `tpair`, `tproject1`). The shaped, ranked and mixed styles interoperate freely; conversions are zero-cost (`Core/ConvertTensor.hs`, `Core/Conversion.hs`).
+
+### Two AD pipelines (`HordeAd.ADEngine`)
+
+1. **Concrete AD** (`cgrad`, `cjvp`, `cvjp`): instantiates the function at `ADVal Concrete`. Sharing is preserved automatically; permits dynamic control flow; differentiation happens on every call.
+2. **Symbolic AD** (`grad`, `vjp`, `jvp`, `vjpArtifact`, ...): instantiates at `AstTensor`, differentiates the AST once into a derivative "artifact" program, which is simplified and can then be interpreted many times on different inputs. Sharing must be marked explicitly with `tlet`.
+
+Reverse-mode differentiation itself goes through **delta expressions** (`Core/Delta.hs`): a sparse representation of the linear map that is the derivative. `Core/DeltaEval.hs` transposes/evaluates it (`gradientFromDelta`, `derivativeFromDelta`), related, for all `d`, `dt` and `ds`, by `dt <.> derivativeFromDelta d ds = gradientFromDelta d dt <.> ds` — a property checked in the testsuite.
+
+### AST processing pipeline
+
+- `Core/AstVectorize.hs` — BOT (bulk-operation transformation): eliminates `build1`/indexing-under-build, which would otherwise explode delta expressions.
+- `Core/AstSimplify.hs` — smart constructors that simplify by inspecting term roots; `Core/AstTraverse.hs` — full bottom-up simplification passes; `Core/AstInline.hs` — inlining and global sharing elimination; orchestrated by `Core/AstEngine.hs` (`simplifyArtifactRev`, etc.).
+- `Core/AstInterpret.hs` + `Core/AstEnv.hs` — interpret AST terms in any tensor-class instance (the backend).
+- `Core/PPEngine.hs`, `Core/PPTools.hs` — pretty-printing of ASTs/artifacts.
+
+A deliberate layering rule (documented in `Core/Ast.hs` and `Core/Ops.hs`): `Ast*` modules (syntax) and `Ops*`/`Carriers*` modules (semantics) rarely depend on each other; they meet only in `AstInterpret`/`AstEnv` (syntax → semantics) and `OpsAst`/`CarriersAst` (semantics built from syntax).
+
+### Supporting pieces
+
+- `Core/Adaptor.hs` — `AdaptableTarget` converts user-level collections (tuples, lists of tensors) to/from a single tensor-kind representation `X vals`; this is how `grad` accepts functions over tuples.
+- `Core/Unwind.hs` (and its more precisely-typed copy `Core/UnwindNum.hs`) — generic operations over nested product tensor kinds.
+- `HordeAd.OpsTensor{,Ranked,Shaped,Mixed}` — the user-facing operation surface re-exported by the top-level `HordeAd` module; `Core/Ops.hs` holds the rawer class methods.
+- `External/` — optimizers (SGD, Adam) and common NN building blocks.
+- `example/` (public sublibrary `exampleLibrary`) — MNIST neural nets (fully connected, convolutional, recurrent; ranked and shaped variants) used by tests and benchmarks.
+
+## Performance model
+
+Runtime performance is an emergent property of four layers — AST term rewriting, the interpreter and its concrete kernels, GHC's optimizer, and the CPU — so it is decided empirically, not by reading source; a cost-centre profile is cheap to obtain (`--enable-profiling --profiling-detail=late` reuses the -O1 dependency store and rebuilds only the local packages). `contractAst` in `Core/AstTraverse.hs` (the backend-recognition pass, run just before interpretation) is by its own docstring "defined in an ad-hoc way based on benchmarks"; treat any rewrite-rule change there as benchmark-gated.
+
+Rules that keep the measurements honest:
+
+- **Only criterion numbers belong in comparison tables and in performance reasoning.** A tasty "Bench" total (the `TestConvQuickCheck` poor man's benchmarks: wall-clock / 100 runs, including per-run random generation and `allClose`, on a coarse ~10ms timer) and a criterion per-call number are *different quantities*; never put both in one table, row or column. Treat any non-criterion figure — a GitHub issue's numbers, tasty totals (which are also machine/context/GC-dependent and not portable across setups or time) — as *anecdotal*: mention it as such, don't base a conclusion on it.
+- **Attribute a performance difference by controlled experiment, not hypothesis.** A ~3.3x gap between conv-gradient benchmarks, blamed in turn on harness noise and machine/GHC differences, was really a per-call artifact rebuild — settled by a discriminating benchmark (artifact hoisted out of the timed loop vs rebuilt per call); rule out machine/GHC only once the setup is confirmed identical. Before a number enters a commit message or public doc, ask what *instrument* produced it and whether a cheaper decisive check (printed-AST churn location, a provably-unaffected control) settles the question first.
+- **An A/B across two *builds* needs interleaving and controls, because recompilation itself moves numbers.** Two binaries differing by a one-line toggle shift *unaffected* benchmarks by ±2–5% (code-layout/codegen noise), and batched runs (all A, then all B) additionally confound with time/thermal drift. Run interleaved A/B pairs (drift cancels within a pair) and include per-pair controls: a suite the change provably cannot affect (e.g. the concrete `VTA` MNIST groups of `BenchMnistTools` for a `contractAst` change — the concrete pipeline never runs it), and/or a change-independent variant (e.g. `S-exec-raw` for a `contractAst` change: the raw artifact is contraction-independent — see the `vjpArtifact` bullet below — so it is identical across the toggle). The change's effect is the target's per-pair ratio minus the control's.
+- **The printed-AST tests are a free, decisive oracle for "can this rewrite affect that program at all".** An unchanged printed artifact means a byte-identical artifact and hence identical interpretation, so checking *where* a rewrite's printed-AST churn falls, before benchmarking, can settle a claim in minutes — a purported MNIST speedup was disproved this way (the churn was confined to CNN tests, so FC-MNIST could not have moved).
+- **Benchmark inputs must be random, not broadcast constants.** A constant input like `treplicate … (sscalar 7)` is a stride-0 broadcast that the simplifier constant-folds *through* the very operations you mean to time — a CNN gradient benchmark with a constant glyph lost its im2col gathers to folding and under-measured 24ms vs the honest 158ms. Use `randomValue`; a constant is only right when the *test* (e.g. a printed-AST test) wants a canonical small term.
+
+Cost facts worth knowing before optimizing:
+
+- **The two AD pipelines have different cost shapes.** `cgrad`/`cvjp` re-run differentiation on every call; the symbolic tools (`grad`/`vjp`) pay tracing + `simplifyUserCode` + AD + `simplifyArtifactRev` once — a roughly size-independent overhead — then only interpret the artifact per call. Intended usage: build the artifact once (`vjpArtifact`/`gradArtifact`/`revArtifactAdapt`), interpret it many times (`vjpInterpretArtifact`); a benchmark calling full `vjp` per iteration conflates pipeline cost with execution cost.
+- **`sreplicate`, `sreplicateN`, `stranspose` are metadata-only** (stride tricks; ox-arrays `X.replicate` is stretch-to-stride-0), and the ox-arrays dot and elementwise kernels (`Data.Array.Strided.Arith`) are stride-aware. Broadcasts and transposes fed into a dot or a `*` do **not** materialize, so don't rewrite them away on the assumption that they allocate.
+- **`tssumN` is iterated `tssum`** (`Core/OpsConcrete.hs`): one full pass and allocation per summed dimension.
+- **Interpreted `sgather` dominates gather-heavy programs** (the im2col patch arrays of convolution gradients — often ~two thirds of runtime). It runs through ox-arrays' `mgenerate`: per output position (the `shm` dims) evaluate the index and copy a slice (the `shn` dims); the per-element boxed-`Integer` index arithmetic is the hot loop. Two benchmark-confirmed consequences: (1) `contractAst` sorts a gather's `shn` dimensions ascending, via metadata-only compensating transposes, so the largest dimension is innermost and the copy's inner loop amortizes the per-step overhead — reordering the `shm` dims, by contrast, changes nothing; (2) fusing two gathers into one is a *pessimization* — it trades few large-slice copies for many tiny ones while `mgenerate`'s cost is per position — so the phase-gating that prevents that fusion is intentional, and sorting cannot rescue the fused form (its `shm` order measures flat, the `fused-gather-shm-sorted-*` benches; its `shn` is tiny and already sorted, fusion having consumed the large dims into the index function). One level down, the per-step cost is orthotope's run-decomposition of each strided slice (`toVectorListT`), with a per-element fallback when the innermost dim is strided. Reducing it further has two candidate designs, neither implemented yet: the two-stage upstream (ox-arrays/orthotope) fix in the [#123](https://github.com/Mikolaj/horde-ad/issues/123) material, and the client-side add-zero gather of `notes-add-zero-gather.md` (repo root, committed) — gather rebuilt on the scatter model, each strided slice densified through the stride-aware C arith kernels by adding a replicated scalar zero (normalize-in-C with a fused redundant add); it needs no upstream release and the `scatter48` bound prices it at ~7–10× on the isolated chains. The note's Consequences section records what the design changes in the staged drafts.
+- **Concrete scatter is slice-based and ~8–10× cheaper than gather on the same index map and strided-read workload** (`scatter48` ~0.55ms vs `gather48` ~4–6ms). As gather's transpose it performs the same element transfers and, where the index map is many-to-one, even more arithmetic — it sums where gather copies — so the gap is code path, not data volume. The path: `tscatterZSScalar` does per-position index eval + `IntMap.insertWith (+)` with whole-slice adds through the stride-aware `NumElt` C kernels, then flat `VS.copy` write-outs — the interpreted Haskell is per *chunk*, all element traffic is C. The accumulation is what dodges the Haskell strided-normalize (it consumes strided views in C and leaves dense buffers to memcpy), a trick the current gather doesn't borrow, though the add-zero design above shows how a sum-free gather could: force a redundant add. Corollaries: extending the `shn`-sort to scatter is an outright pessimization, measured ~4.4× (`two-scatters-ad-shn-sorted`, 2.3ms vs 0.52ms) — each slice is added as one flat vector, so a sorted `shn` has no per-`shn`-dim loop to amortize, while the compensating transposes leave the slice views strided; scatter in its natural orientation is the empirical bound for a fast gather path (its strid-ified and fused forms are far slower); and a rewrite's whole-program effect grows with problem size, converging toward the dominant op's win (the `shn`-sort is negligible on small overhead-bound nets, ~18% on a 24×24 CNN gradient once gathers dominate).
+- **`vjpArtifact` does not run `contractAst`** — it runs `simplifyUserCode` + `revProduceArtifactDt`; `contractAst`'s only caller is `simplifyInlineContract`, which `simplifyArtifactRev` and its `Fwd` sibling apply to artifacts (convVjpBench's handwritten-term variants also call it directly). Hence the *raw* artifact is contraction-independent — which explains `S-exec-raw`'s role as an A/B control and means "artifact" benchmarks measure different pipelines depending on whether they stop at `vjpArtifact` or add `simplifyArtifactRev`.
+
+Adding a `contractAst` rewrite rule: put it in `contractAst`, not a smart constructor (which fires in every phase and reshapes intermediates other rules match on), applied at a node's exit and *after* any case that hoists structure out of the same constructor and re-enters `contractAst`. Make it idempotent, and identify which existing rules could undo the form it introduces — for the `shn`-sort, `astTransposeS`/`astGatherCase` only absorb *leading*-dims permutations while the compensating transposes permute trailing dims — recording that argument as a code comment at the rule.
+
+## Coding style
+
+Author-generic style conventions are collected in the portable-notes section at the end of this file; what follows is horde-ad-specific.
+
+- `StrictData` is on, plus `TypeFamilies`, `PatternSynonyms`, etc. — see `common options` in the cabal file. Type-level shape arithmetic relies on the `ghc-typelits-knownnat` and `ghc-typelits-natnormalise` plugins.
+- **Float epsilon margins depend on magnitude, GHC version and machine.** When compared values are large (e.g. gradients reaching ~5e5, where one Float ulp is ~0.03), widen the `assertEqualUpToEpsilon` margin rather than pinning exact low ulps or rewriting the expected values to one machine's output.
+
+## Testing and correctness
+
+- **Benchmarks are not correctness tests.** A body that forces a result by comparing it to itself (`allClose v v`) checks only that the body compiles — it never catches a wrong-operator or copy-paste bug — so when cloning a variant, cross-check every analogous position by hand: the operator called, the data helper used, the point at which a derivative artifact is interpreted. Every benchmarked path needs a *separate* `assertEqualUpToEpsilon` check on same-shaped data — hence deterministic correctness in `TestConvCorrect` alongside the poor man's benchmarks in `TestConvQuickCheck` — though existing tests of closely similar code suffice (the `cnn-*` benchmark groups lean on the many CNN tests).
+- **Deterministic vs QuickCheck split for stable timing.** Keep QuickCheck properties and poor man's benchmarks in one module (`TestConvQuickCheck`) and deterministic `testCase` correctness in another (`TestConvCorrect`), so the deterministic suite's wall-clock stays comparable across runs. Share helpers by *exporting* them from the QuickCheck module (no import cycle).
+- **Printed-AST regression churn** after simplifier changes is expected and mechanical: refresh the expected strings from a sequential `CAFlessTest` run (parse the tasty-hunit expected/but-got pairs; expect two or three rounds, since each test stops at its first failing assertion), keep that churn in its own commit, and watch for eps-based numeric tests (e.g. `3barS`) drifting in the last Float digit when operation order changes.
+- **`cnnObjective` (exported from `TestMnistPP`) is the objective shared between a printed-AST test and its benchmark**: `testCNNOPP2S` consumes it with a constant glyph at print-friendly sizes, `convVjpBench`'s `cnn-*` groups with a random glyph at square doubling sizes — the benchmark provably measures the net the test validates, and the refactor is verified free by the printed-AST test not churning.
+
+## Portable notes: same author, same machine
+
+Nothing in this section is horde-ad-specific: it should hold for other projects by the same author, in the same coding style, developed on the same machine behind the same outer sandbox. Examples are from horde-ad unless attributed.
+
+### Coding style
+
+- Haddocks are expected on all module headers and on functions/types in "major"/interface modules. Minor internal helpers get no haddocks; their comments, if any, must not be haddocks and may describe implementation details and go out of date — don't treat every comment as authoritative documentation.
+- Prefer assertions over comments to document invariants, unless that would be too verbose.
+- `-fno-ignore-asserts` stays on in the cabal `common options` stanza, so failed `assert`s crash release builds too — crash reports from released code can name assertions.
+- Lens libraries are deliberately avoided; state lives in plain records (with record punning).
+- GHC2024 is the default language; each project's default-extensions live in the cabal `common options` stanza. Projects normally set `StrictData` — assume it unless the project's notes say otherwise.
+- Formatting (also spelled out in the README's Coding style section): 2-space indent, 80 columns, spaces not tabs, spurious whitespace avoided, spaces around arithmetic operators encouraged. Inline comments (`--`) are prefixed with exactly two spaces, unless indented to match other comments. Operators such as `(` and `,`, `<$>` and `<*>`, comment starts, etc. on consecutive lines either align or, if that would make lines too long, indent by 2 spaces from the previous indentation level. Generally, relax and stick to the style apparent in the file being edited.
+- Put large, mechanical formatting changes in their own commit, separate from substantive changes.
+- If hlint is still too naggy, adding more exceptions to `.hlint.yaml` is fine — don't contort code to appease it.
+- **Uniformity across analogous positions is itself a review tool.** Parallel code (e.g. the `Preserving`/`Shrinking`/`Padded` × `dKrn`/`dInp` × size families in the conv tests) and its comments should be identical modulo names and shapes; diffing analogous positions is how bugs surface, and a drifted one is normalized toward the cleaner form, not the first draft. One level up, things meant to be compared (benchmark variants, test cases) are designed as one-to-one counterparts — measuring the same stage, differing only along the compared axis, adjacent in the output — not accreted one probe at a time.
+- **Order definitions as they are used, and let every summary span its whole subject.** Auxiliary definitions, do-bindings, list entries and top-level functions follow the order in which their consumers run, print or assert, wherever that order is deliberate or visible; an overview (module haddock, section comment) covers every member of what it describes, not the subset that existed when it was written. Both properties decay silently under accretion — after adding to a set, re-normalize the whole set, not just the new member.
+- **One meaning per name, and label deliberate asymmetries.** A letter or abbreviation keeps a single meaning per vocabulary (not `S`/`H` as both the pipelines and the gather orientations they produce, nor `c` as both concrete and contracted); and where uniformity is intentionally broken — a counterpart deliberately absent, a definition that is a fixture rather than a candidate — the site says so and why: an unexplained asymmetry reads as drift and costs a review round-trip.
+- **Comments.** A substantial note that sibling sites would repeat with only names changed is stated once, at its canonical occurrence; tiny notes, by contrast, are repeated identically at every analogous position. Match the codebase's spelling and hyphenation (e.g. "poor man's", not "poor-man's") and keep terminal punctuation consistent across parallel clauses (don't end one with ";" and its sibling with "."). A comment must still match the code after refactors — watch for notes invalidated by later changes. Leave pre-existing comments alone unless asked — flag them instead.
+- In tests, an expected crash may never fire due to laziness: an assertion or lookup error is swallowed if the offending value is never forced (force it — under `StrictData`, WHNF fully builds an AST). Catch real assert failures with `Control.Exception.try`, rather than pattern-matching on output; the `blame`/`swith` details (from the `assert-failure` package) go to the trace output, not into the exception.
+- **Prove a self-checking assertion is non-vacuous.** An invariant check — e.g. verifying that scatter is the adjoint of gather via `sdot0 (sgather x f) y == sdot0 x (sscatter y f)` — should be shown to actually fail when the property is deliberately broken, or it may be passing vacuously.
+- Share the objective between a test and its benchmark via one exported helper, parameterized by what differs, so the benchmark provably measures what the test validates — share code, not configuration.
+
+### Working style
+
+- **Scope discipline.** On an ambiguous request ("the *new* tests") take the narrower reading, do it, and flag the boundary with an offer to expand — don't silently touch pre-existing code. Split unrelated work into separate PRs (e.g. convolution benchmarks + tests in one PR, the simplifier fix in another).
+- **Verify before claiming done.** "Uniform" / "correct" / "passes" must rest on an actual line-by-line cross-check or a test run, not on the fact that it compiled; a claim about a touched file covers its pre-existing code too, so audit that as well.
+- **Only/every/never claims must rest on repo-wide grep, not on the file where the pattern was first noticed** — analogous-variant families (`Preserving`/`Shrinking`/`Padded` × `dKrn`/`dInp`, the ranked/shaped/mixed op surfaces, the `Ops*` instances) make single-file generalization treacherous. The same discipline applies before concluding "this cannot happen here": grep for *every* site that could do it.
+- **Commits should be clean and logical, not a diary of the work.** File-partition them, order them so exports precede uses, and fold a follow-up refactor into the commit where the code is logically born rather than adding "add then move" churn.
+- **Never push, or open/force-update a PR, without an explicit go-ahead.** Permission to make a change is not permission to publish it.
+- **Record don't-do rulings next to the do's.** Refuted designs live in the working documents together with the evidence that killed them, precisely so they aren't re-proposed later; when a new idea dies to evidence, write the ruling down where the next reader will look. (E.g. gather fusion, the `shm` flip and the summation-structure rewrite, each recorded with its killing measurement in the [#123](https://github.com/Mikolaj/horde-ad/issues/123) material.)
+- **Drafting GitHub-bound texts**: one file per destination (issue, its design comment, PR description, upstream PR), staged in the repo root until posted; keep the *design* implementation-ignorant and put measured results in the PR description; deliberate overlap between files is fine to make each self-contained. Don't attribute design intent to code that is merely generic ("assumes irregular indexing") — state observed granularity and cost, not motives. Prefer reference-style markdown links so prose stays within 80 columns.
+- **Links that cite source code — in GitHub-bound texts and the reference documents — must be GitHub permalinks pinned to a commit hash that is on `master`** (`…blob/<commit>/….hs#L12-L34`): branch-name and unpinned links drift or die when branches move, while a master hash survives rebases and stays verifiable — the citation checker validates such permalinks against the pinned commit. Deliberately-living whole-file links (e.g. the README's `blob/master` pointers) are outside the rule, as are links to foreign repos, which the checker cannot verify.
+- **State mathematical properties in the code's surface notation, not abstract math** (in docs and comments alike). Write the gather/scatter adjoint law as `sdot0 (sgather x f) y == sdot0 x (sscatter y f)`, not `⟨gather x, y⟩ = ⟨x, scatter y⟩`: keep the index function `f` explicit rather than hidden in the operator name, and put quantifiers first (*for all `f`, `x`, `y`*). It reads in the vocabulary of the code and keeps the shapes checkable.
+
+### Document verification: the three-pass discipline
+
+Planning/reference documents (this file and any GitHub-bound drafts staged in the repo root) make checkable claims. Whenever such a document (or code it cites) is edited, run three passes:
+
+1. `python3 tools/check-plan-citations.py [DOC]` (from the repo root; DOC defaults to this file) — re-validates `file:line` citations, resolving each, checking the line range and printing the first cited line to eyeball against the surrounding claim, and pinned GitHub permalinks against the commit they name via `git show`, so those never drift; foreign-repo links can't be verified locally.
+2. Check that paths, cabal targets and flags named in prose exist.
+3. Re-verify only/every/never claims by repo-wide grep.
+
+The passes are ordered by yield: the mechanical ones catch drift, but the quantified-claims grep has found real, long-standing errors every time it has been run, so it is the pass never to skip.
+
+### Sandboxing on the dev machine (outer wrapper + inner sandbox)
+
+Claude Code sessions on Mikolaj's machine run inside an outer bwrap sandbox wrapper (PID 1 is `bwrap`), beyond Claude Code's own (inner) sandbox. Current state and its implications:
+
+- Run `git` writes, `cabal` and `gpg` unsandboxed — the inner sandbox mounts `.git/config`, `~/.cabal` and `~/.gnupg` read-only. `git checkout -b` / `branch -f` fail to lock the config, though the ref often moves anyway — verify refs afterwards. GPG signing (`commit.gpgsign` is on) fails sandboxed and works unsandboxed, so never fall back to `--no-gpg-sign`; SSH pushes likewise work only unsandboxed. Other read-only HOME mounts (e.g. `~/.claude/projects`) also need unsandboxed commands for deletions.
+- An unsandboxed (or otherwise permission-gated) command sits at the approval prompt until answered — on the user's screen indistinguishable from a hung long-running command — so before issuing an optional or expensive one (a haddock run, an extra rebuild), say what is about to appear.
+- Paths the wrapper blocks report "No such file or directory", not "Permission denied". If a path outside the repo seems missing — especially one documented as expected, like the `../ox-arrays` sibling checkout — suspect the wrapper and ask, rather than record the path as absent. `dangerouslyDisableSandbox` bypasses only the inner sandbox, never the wrapper.
+- The wrapper mounts a hand-picked, changeable subset of HOME, curated per-path rather than per-directory: that an entry is visible says nothing about how much of its contents is (at times `~/r` has held only the current repo, and `~/.ssh` carries public material only). Don't infer access from a directory listing and don't record mount inventories — they go stale; verify the specific path at the moment it matters.
+- Inside the inner sandbox, HOME appears to be the repo root, so sandboxed `git status`/`ls` show phantom untracked dotfiles (`.bashrc`, `.gitconfig`, `.vscode`, ...) that don't exist on the real filesystem. Ignore them; verify with an unsandboxed command before deleting any.
+- System state under wrapper-hidden paths (e.g. `/etc/apparmor.d`) cannot be inspected from inside a session; such diagnosis must be done by Mikolaj in a plain terminal.
+- The nested inner sandbox works only because three things hold: the Ubuntu AppArmor userns restriction is off (`kernel.apparmor_restrict_unprivileged_userns=0`, no `bwrap-userns-restrict` profile), the wrapper mounts the repo read-write, and `enableWeakerNestedSandbox: true` is in effect — inherited from the `sandbox` block of the user-level `~/.claude/settings.json` (a project `sandbox` block wholesale replaces the user-level one — settings objects don't deep-merge — so a project that defines one must repeat the flag). If sandboxed commands start failing at startup, check these three first.
+
+### Git and GitHub in sessions
+
+- Interactive git is unavailable (tool commands run without a TTY, so editor and prompt loops hang): no `rebase -i`, no `add -i`. Rewrite history with `git reset --mixed <base>` + re-`add`/`commit` per file group, reusing messages via `git commit -C <hash>` / `-F <file>`.
+- Amending a non-HEAD commit (no `rebase -i`): save working-tree edits as a patch, `git reset --hard <target>` (spares untracked files), apply, `--amend`, then `git cherry-pick` the successors (conflict-free when they don't touch the amended files); update recorded hashes.
+- The repo root accumulates many untracked scratch files (`log*`, `*.prof`, `cabal.project.local.bkp*`, `.emacs.desktop*`, etc.); leave them alone and never `git add` them wholesale.
+- `gh` is not authenticated; for GitHub reads use `curl` against `api.github.com` (on the sandbox network whitelist).
+
+### Build and shell tooling in sessions
+
+- `awk` works through `~/.local/bin/awk → mawk` (added 2026-07-21): `/usr/bin/awk` is an alternatives symlink that dangles in sessions, `/etc/alternatives` being wrapper-hidden.
+- To combine several tasty `-p` patterns, tasty wants awk-style syntax: `-p "/foo/ || /bar/"`.
+- GHC emits warnings only on *recompilation*: a cached, up-to-date build can hide warnings (e.g. `-Wredundant-constraints`) that a full rebuild would surface — don't infer "no warnings" from a clean second build.
+- Keep one set of cabal flags across a session — changing flags (e.g. toggling `--enable-optimization` or `--enable-profiling`) forces a full rebuild of the local packages, though each flag set's dependency builds stay cached in the store. Pass such flags on the command line rather than editing `cabal.project.local`.
+- The `/tmp` scratchpad is wiped by a machine restart — put anything that must survive (patches, notes) in the repo tree; binaries just get rebuilt.
+- Exact dependency sources are always available: unpack `~/.cabal/packages/hackage.haskell.org/<pkg>/<ver>/` matching `dist-newstyle/cache/plan.json`.
+- `.github/workflows/haskell-ci.yml` is generated by `haskell-ci` from the `.cabal` file — regenerate it rather than hand-editing, and re-apply any hand-maintained steps afterwards (the `tests` and `benchmarks` steps, marked by a comment in the workflow).
+- Toggle-based A/B builds: make a rule's guard unsatisfiable (e.g. `sigmaL /= sigmaL`), build and copy the binary aside, restore + rebuild + copy again, then run the two preserved binaries in interleaved pairs (no rebuild between A and B); an edited `Core` module rebuilds in ~10 min.

--- a/README.md
+++ b/README.md
@@ -257,9 +257,13 @@ Stylish Haskell is used for slight auto-formatting at buffer save; see
 [.stylish-haskell.yaml](https://github.com/Mikolaj/horde-ad/blob/master/.stylish-haskell.yaml).
 As defined in the file, indentation is 2 spaces wide and screen is
 80-columns wide. Spaces are used, not tabs. Spurious whitespace avoided.
-Spaces around arithmetic operators encouraged.
-Generally, relax and try to stick to the style apparent in a file
-you are editing. Put big formatting changes in separate commits.
+Spaces around arithmetic operators encouraged. Inline comments (`--`)
+should be prefixed with exactly two spaces, unless indented to match
+other comments. Operators such as `(` and `,`, `<$>` and `<*>`, comment
+starts, etc. on consecutive lines should either align or, if that would
+make lines too long, should be indented by 2 spaces from the previous
+indentation level. Generally, relax and try to stick to the style apparent
+in a file you are editing. Put big formatting changes in separate commits.
 
 Haddocks should be provided for all module headers and for the main
 functions and types from the most important modules.

--- a/bench/ConvVjpBench.hs
+++ b/bench/ConvVjpBench.hs
@@ -2,7 +2,7 @@
 -- | Diagnostic benchmarks for issue #123: separate the cost of the
 -- symbolic AD pipeline (tracing, differentiation, simplification)
 -- from the cost of executing the resulting gradient program,
--- for the gradient of conv2dSameS with respect to the kernels,
+-- for the gradient of conv2dPreservingS with respect to the kernels,
 -- at several array sizes.
 --
 -- Variants, mirroring the QuickCheck poor man's benchmarks
@@ -46,7 +46,7 @@ import HordeAd.Core.Adaptor (randomValue)
 import HordeAd.Core.AstEnv (emptyEnv, extendEnv)
 import HordeAd.Core.AstInterpret (interpretAstFull)
 
-import TestConvQuickCheck (conv2dSame_dInp, conv2dSame_dKrn)
+import TestConvQuickCheck (conv2dPreserving_dInp, conv2dPreserving_dKrn)
 
 forceGrad :: Concrete (TKS sh Double) -> Double
 forceGrad = unConcrete . ssum0
@@ -90,11 +90,11 @@ benchesAt = do
                     0.5 seed3
       f :: AstTensor AstMethodLet FullSpan (TKS '[nCout, nCinp, nKh, nKw] Double)
         -> AstTensor AstMethodLet FullSpan (TKS '[nImgs, nCout, nAh, nAw] Double)
-      f k = conv2dSameS k (sconcrete (unConcrete arrA))
+      f k = conv2dPreservingS k (sconcrete (unConcrete arrA))
       -- The handwritten gradient built as an AST term; constructing it
       -- runs vectorization (sbuild at the AST target).
       hTerm :: AstTensor AstMethodLet FullSpan (TKS '[nCout, nCinp, nKh, nKw] Double)
-      hTerm = conv2dSame_dKrn @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
+      hTerm = conv2dPreserving_dKrn @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
                               (sconcrete (unConcrete arrA))
                               (sconcrete (unConcrete arrB))
       hTermSimplified = simplifyInlineContract hTerm
@@ -105,7 +105,7 @@ benchesAt = do
                                     (FTKScalar @Double))
                               (intToAstVarId 100000099)
       hTermVar :: AstTensor AstMethodLet FullSpan (TKS '[nCout, nCinp, nKh, nKw] Double)
-      hTermVar = conv2dSame_dKrn @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
+      hTermVar = conv2dPreserving_dKrn @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
                                  (sconcrete (unConcrete arrA))
                                  (AstVar varNameB)
       hTermVarSimplified = simplifyInlineContract hTermVar
@@ -131,7 +131,7 @@ benchesAt = do
       -- rebuilt every iteration: this honestly measures the full pipeline.
     , bench "S-fullpipe-honest" $ whnf
         (\a -> forceGrad
-               $ vjp (\k -> conv2dSameS k (sconcrete (unConcrete a))) arrK arrB)
+               $ vjp (\k -> conv2dPreservingS k (sconcrete (unConcrete a))) arrK arrB)
         arrA
       -- Building + simplifying the artifact only (the "compilation" cost),
       -- forced to WHNF as in mnistTrainBench2VTC (BenchMnistTools): with
@@ -151,7 +151,7 @@ benchesAt = do
                    :: Concrete (TKS '[nCout, nCinp, nKh, nKw] Double))) arrB
     , bench "H-fullpipe" $ whnf
         (\b -> forceGrad $ interpretAstFull emptyEnv
-                 $ conv2dSame_dKrn @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
+                 $ conv2dPreserving_dKrn @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
                                    (sconcrete (unConcrete arrA))
                                    (sconcrete (unConcrete b))) arrB
     , bench "H-exec" $ whnf
@@ -184,9 +184,9 @@ benchesInpAt = do
       -- Differentiate with respect to the input, with the kernel baked in.
       g :: AstTensor AstMethodLet FullSpan (TKS '[nImgs, nCinp, nAh, nAw] Double)
         -> AstTensor AstMethodLet FullSpan (TKS '[nImgs, nCout, nAh, nAw] Double)
-      g a = conv2dSameS (sconcrete (unConcrete arrK)) a
+      g a = conv2dPreservingS (sconcrete (unConcrete arrK)) a
       hTerm :: AstTensor AstMethodLet FullSpan (TKS '[nImgs, nCinp, nAh, nAw] Double)
-      hTerm = conv2dSame_dInp @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
+      hTerm = conv2dPreserving_dInp @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
                               (sconcrete (unConcrete arrK))
                               (sconcrete (unConcrete arrB))
       hTermSimplified = simplifyInlineContract hTerm
@@ -194,7 +194,7 @@ benchesInpAt = do
                                     (FTKScalar @Double))
                               (intToAstVarId 100000099)
       hTermVar :: AstTensor AstMethodLet FullSpan (TKS '[nImgs, nCinp, nAh, nAw] Double)
-      hTermVar = conv2dSame_dInp @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
+      hTermVar = conv2dPreserving_dInp @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
                                  (sconcrete (unConcrete arrK))
                                  (AstVar varNameB)
       hTermVarSimplified = simplifyInlineContract hTermVar
@@ -211,7 +211,7 @@ benchesInpAt = do
         (\dt -> forceGrad $ vjp g arrA dt) arrB
     , bench "S-fullpipe-honest" $ whnf
         (\k -> forceGrad
-               $ vjp (\a -> conv2dSameS (sconcrete (unConcrete k)) a) arrA arrB)
+               $ vjp (\a -> conv2dPreservingS (sconcrete (unConcrete k)) a) arrA arrB)
         arrK
       -- Artifact build+simplify only, WHNF-forced; see 'benchesAt'.
     , bench "S-artifact" $ whnf
@@ -226,7 +226,7 @@ benchesInpAt = do
                    :: Concrete (TKS '[nImgs, nCinp, nAh, nAw] Double))) arrB
     , bench "H-fullpipe" $ whnf
         (\b -> forceGrad $ interpretAstFull emptyEnv
-                 $ conv2dSame_dInp @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
+                 $ conv2dPreserving_dInp @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
                                    (sconcrete (unConcrete arrK))
                                    (sconcrete (unConcrete b))) arrB
     , bench "H-exec" $ whnf
@@ -477,9 +477,9 @@ printTerms = do
                     0.5 seed3
       f :: AstTensor AstMethodLet FullSpan (TKS '[nCout, nCinp, nKh, nKw] Double)
         -> AstTensor AstMethodLet FullSpan (TKS '[nImgs, nCout, nAh, nAw] Double)
-      f k = conv2dSameS k (sconcrete (unConcrete arrA))
+      f k = conv2dPreservingS k (sconcrete (unConcrete arrA))
       hTerm :: AstTensor AstMethodLet FullSpan (TKS '[nCout, nCinp, nKh, nKw] Double)
-      hTerm = conv2dSame_dKrn @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
+      hTerm = conv2dPreserving_dKrn @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
                               (sconcrete (unConcrete arrA))
                               (sconcrete (unConcrete arrB))
       hTermSimplified = simplifyInlineContract hTerm
@@ -487,7 +487,7 @@ printTerms = do
                                     (FTKScalar @Double))
                               (intToAstVarId 100000099)
       hTermVar :: AstTensor AstMethodLet FullSpan (TKS '[nCout, nCinp, nKh, nKw] Double)
-      hTermVar = conv2dSame_dKrn @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
+      hTermVar = conv2dPreserving_dKrn @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
                                  (sconcrete (unConcrete arrA))
                                  (AstVar varNameB)
       artifact = simplifyArtifactRev (vjpArtifact f arrK)

--- a/bench/ConvVjpBench.hs
+++ b/bench/ConvVjpBench.hs
@@ -49,6 +49,95 @@
 -- measurement trap (see 'pitfallBenches'), so the sweep groups contain
 -- only honest, pairwise-comparable variants.
 --
+-- The numbered time properties below relate the criterion means of a
+-- full run (the CI smoke run's single iterations cannot support the
+-- tolerance). When analyzing a run, verify them explicitly, in this
+-- order, each up to 10% tolerance: @a == b@ stands for
+-- @abs (a - b) <= max a b / 10@, and @a <= b@ for @a <= 1.1 * b@.
+-- tools/check-conv-bench-props.py, fed criterion's @--csv@ output, is
+-- this list in executable form; keep the two in sync — the script
+-- fails on a benchmark that no property touches, so adding a benchmark
+-- forces this list to be re-normalized. The list is minimal — anything
+-- derivable from it and the nonnegativity of times, e.g.
+-- @time(S-exec) <= time(S-fullpipe-honest)@ from property 1, is
+-- deliberately not listed.
+--
+-- The properties fall into two groups. Properties 1-3 hold for any
+-- engine whatsoever, by accounting alone: a whole equals the sum of
+-- its parts, and a part does not exceed its whole. A violation there
+-- means the measurement itself broke — work hoisted out of a timed
+-- call, double-counted, or drowned in noise. Properties 4-15 describe
+-- the current engine and may legitimately change when engine code
+-- changes — e.g. once the faster gather kernels designed for issue #123
+-- (the add-zero gather of notes-add-zero-gather.md or the upstream
+-- normalize-in-C) are implemented. They subdivide further:
+--
+-- * property 4 records what the simplifier does /not/ do to embedded
+--   constants — the random-data methodology leans on it, and so does
+--   the left edge of property 2;
+--
+-- * properties 5-6 are invariants any acceptable engine must keep, so
+--   a violation is an engine regression to fix, never a property to
+--   update;
+--
+-- * properties 7-15 record the cost model of the current interpreted
+--   gather and scatter kernels — the rulings behind contractAst's
+--   gather rewrites — and are exactly the ones to re-measure, and
+--   update together with those rewrites, when the kernels change.
+--
+-- 1. @time(S-fullpipe-honest) == time(S-artifact) + time(S-exec)@, in
+--    every group with all three variants (both sweeps at every size and
+--    the @cnn-*@ groups): @vjp@ is artifact construction plus
+--    interpretation, so a violation means work got hoisted out of, or
+--    double-counted in, the timed call.
+-- 2. @time(H-exec-raw) <= time(H-fullpipe)@ and
+--    @time(H-fullpipe) <= time(H-term) + time(H-exec-raw)@, in every
+--    sweep group at every size — only a sandwich, because @H-fullpipe@
+--    interprets the never-contracted term: its build portion is bounded
+--    above by @H-term@, which additionally contracts. The left edge
+--    also leans on property 4, since @H-fullpipe@'s cotangent is an
+--    embedded constant where @H-exec-raw@'s is a variable.
+-- 3. @time(6x6/S-exec) <= time(pitfalls/S-fullpipe-hoisted-6x6)@ and
+--    @time(pitfalls/S-fullpipe-hoisted-6x6) <= time(6x6/S-fullpipe-honest)@
+--    — the hoisted variant does everything exec-only does plus the
+--    adaptor glue, and the honest variant additionally rebuilds the
+--    artifact; that gap is exactly its trap.
+-- 4. @time(pitfalls/H-exec-const-48x48) == time(48x48/H-exec)@:
+--    embedding a random constant cotangent is harmless — simplification
+--    does not fold a random constant through the gathers (a broadcast
+--    constant it would fold).
+-- 5. @time(S-exec) <= time(S-exec-raw)@, in every sweep and @cnn-*@
+--    group, and @time(H-exec) <= time(H-exec-raw)@, in every sweep
+--    group: simplification and contraction must not lose at runtime.
+-- 6. @time(S-exec) <= time(H-exec)@, at every size of both sweeps: since
+--    the gather shn-sort in contractAst, symbolic execution is on par
+--    with the handwritten gradient for dKrn and ahead for dInp.
+-- 7. @time(two-gathers-ad-shm-sorted) == time(two-gathers-ad-orient)@:
+--    gather cost is per output position, so reordering the shm dims
+--    changes nothing.
+-- 8. @time(two-gathers-ad-shn-sorted) <= time(two-gathers-ad-orient)@:
+--    the shn-sort win that the contraction pass banks on.
+-- 9. @time(two-gathers-vec-orient) <= time(two-gathers-ad-orient)@: the
+--    vectorization orientation already has the large dim innermost in
+--    the copied slices.
+-- 10. The four @fused-gather-*@ means are pairwise equal: the fused
+--     form's cost is fixed by its inflated position count, and no
+--     dim-order knob moves it.
+-- 11. @time(two-gathers-ad-orient) <= time(fused-gather-ad-orient)@:
+--     fusing the two gathers is the pessimization.
+-- 12. @time(two-scatters-ad-orient) == time(two-scatters-vec-orient)@:
+--     scatter adds each slice as one flat vector, so the orientation
+--     asymmetry of property 9 cannot appear.
+-- 13. @time(two-scatters-ad-orient) <= time(two-scatters-ad-shn-sorted)@:
+--     the shn-sort must not be extended to scatter.
+-- 14. @time(two-scatters-ad-orient) <= time(fused-scatter-ad-orient)@
+--     and @time(two-scatters-vec-orient) <= time(fused-scatter-vec-orient)@
+--     — both stated, because no equality between the two fused scatters
+--     is pinned: their orientations differ by about the tolerance.
+-- 15. @time(two-scatters-ad-orient) <= time(two-gathers-ad-orient)@:
+--     scatter in its natural orientation is the empirical bound for a
+--     fast gather path.
+--
 -- Setting @PRINT_TERMS=1@ prints the compared gradient programs instead
 -- of benchmarking (see 'printTerms').
 module Main (main) where

--- a/bench/ConvVjpBench.hs
+++ b/bench/ConvVjpBench.hs
@@ -1,78 +1,83 @@
 {-# LANGUAGE AllowAmbiguousTypes, OverloadedLists #-}
--- | Diagnostic benchmarks for issue #123: separate the cost of the
--- symbolic AD pipeline (tracing, differentiation, simplification)
--- from the cost of executing the resulting gradient program,
--- for the gradient of conv2dPreservingS with respect to the kernels,
--- at several array sizes.
+-- | Diagnostic benchmarks for issue #123: separate the cost of producing
+-- a gradient program (tracing, differentiation, simplification) from the
+-- cost of executing it, for the two pipelines that produce one — symbolic
+-- AD and the vectorized handwritten gradient.
 --
--- Variants, mirroring the QuickCheck poor man's benchmarks
--- in TestConvQuickCheck:
+-- The groups @6x6@ to @192x192@ sweep the gradient of conv2dPreservingS with
+-- respect to the kernels across those image sizes; the @inp-*@ groups run
+-- the same variants and sizes for the gradient with respect to the input
+-- image (the @sscatter@ path). Each group holds the variants below in
+-- @S-@/@H-@ pairs — @S@ for Symbolic and @H@ for Handwritten, the issue's
+-- names for the two pipelines — each @H-@ variant measuring the same
+-- stage as its adjacent @S-@ partner, with the incoming cotangent kept as
+-- a variable on both sides (only @H-fullpipe@ embeds it as a constant,
+-- because the tasty benchmark it mirrors does). The pairs decompose the
+-- costs that the QuickCheck poor man's benchmarks in TestConvQuickCheck
+-- conflate:
 --
--- * @S-fullpipe@: @vjp@ per call, i.e., tracing + AD + simplification
---   + interpretation every time (this is what the issue calls Symbolic),
---   in a @-hoisted@ variant (artifact floated out of the timed loop) and a
---   @-honest@ variant (artifact rebuilt every call).
--- * @S-artifact@: building + simplifying the gradient artifact only (the
---   compilation cost), forced to WHNF (StrictData suffices), as in
---   mnistTrainBench2VTC in BenchMnistTools.
--- * @S-exec@: interpreting a pre-computed simplified artifact only.
--- * @S-exec-raw@: interpreting a pre-computed unsimplified artifact,
---   to see what simplifyArtifactRev buys at runtime.
--- * @H-fullpipe@: building + vectorizing + interpreting the handwritten
---   gradient term per call (what the issue calls HandwrittenVectorized).
--- * @H-exec@: interpreting the pre-built handwritten gradient term only.
--- * @H-exec-contracted@: as @H-exec@, but after @simplifyInlineContract@.
--- * @H-exec-var@: as @H-exec-contracted@, but with the cotangent kept as a
---   variable (like in the artifact); the apples-to-apples comparison
---   against @S-exec@.
+-- * @S-fullpipe-honest@ and @H-fullpipe@: the full per-call pipelines
+--   those tasty benchmarks time (the issue's Symbolic and
+--   HandwrittenVectorized) — @vjp@, i.e., tracing + AD + simplification +
+--   interpretation, with the per-call-varying input baked into the
+--   objective so the artifact is genuinely rebuilt every call, vs
+--   building + vectorizing + interpreting the handwritten term, never
+--   contracted.
+-- * @S-artifact@ and @H-term@: the compilation cost only — building and
+--   simplifying the gradient artifact vs building and contracting the
+--   handwritten term, forced to WHNF (StrictData makes that a full
+--   build), as in mnistTrainBench2VTC in BenchMnistTools.
+-- * @S-exec@ and @H-exec@: execution only — interpreting the pre-built
+--   simplified artifact vs the pre-built contracted term (the cotangent
+--   bound in the environment).
+-- * @S-exec-raw@ and @H-exec-raw@: execution of the unsimplified
+--   artifact vs the uncontracted term, to see what simplifyArtifactRev
+--   and simplifyInlineContract buy at runtime.
 --
--- The @inp-*@ groups run the same variants for the gradient with respect
--- to the input image (the @sscatter@ path) instead of the kernels, and the
--- size sweep goes up to 192x192 images.
+-- The @cnn-*@ groups run the @S-*@ variants for a real (shaped) two-layer
+-- convolutional net (@MnistCnnShaped2.convMnistTwoS@, each layer with
+-- maxpool), differentiated with respect to its full parameter tuple, at
+-- image sizes 6x6, 12x12 and 24x24. Unlike the synthetic conv2dPreserving
+-- benchmarks they also exercise the maxpool and reshape gathers of a full
+-- net; they have no @H-*@ variants, as there is no handwritten CNN gradient
+-- to compare against.
+--
+-- The @gather48@ and @scatter48@ groups isolate the dominant cost: the
+-- interpreted im2col gather chains of the 48x48 gradients and their
+-- scatter adjoints (see 'gatherBenches' and 'scatterBenches'). The
+-- @pitfalls@ group holds the suite's single recorder of each known
+-- measurement trap (see 'pitfallBenches'), so the sweep groups contain
+-- only honest, pairwise-comparable variants.
+--
+-- Setting @PRINT_TERMS=1@ prints the compared gradient programs instead
+-- of benchmarking (see 'printTerms').
 module Main (main) where
 
 import Prelude
 
 import Control.Exception (evaluate)
 import Criterion.Main
-import GHC.TypeLits (KnownNat)
+import GHC.TypeLits (Div, KnownNat, type (*))
 import System.Environment (lookupEnv)
 import System.Random (mkStdGen)
 
 import Data.Array.Nested.Shaped.Shape (KnownShS, knownShS)
 
 import HordeAd
-import HordeAd.Core.Adaptor (randomValue)
+import HordeAd.Core.Adaptor (randomValue, toTarget)
 import HordeAd.Core.AstEnv (emptyEnv, extendEnv)
 import HordeAd.Core.AstInterpret (interpretAstFull)
 
+import MnistCnnShaped2 qualified
+import MnistData (SizeMnistLabel)
 import TestConvQuickCheck (conv2dPreserving_dInp, conv2dPreserving_dKrn)
+import TestMnistPP (cnnObjective)
 
 forceGrad :: Concrete (TKS sh Double) -> Double
 forceGrad = unConcrete . ssum0
 
--- | Verify that a hand-built scatter chain is the adjoint (transpose) of the
--- corresponding gather chain, via the identity @<gather(x), y> = <x,
--- scatter(y)>@ that holds iff scatter is gather's transpose. Errors loudly
--- if the scatter chain was built with wrong shapes or index directions.
-checkAdjoint
-  :: (KnownShS shSrc, KnownShS shOut)
-  => String
-  -> AstTensor AstMethodLet FullSpan (TKS shOut Double)  -- ^ gather chain, over @src@
-  -> Concrete (TKS shSrc Double)                         -- ^ the source @x@
-  -> AstTensor AstMethodLet FullSpan (TKS shSrc Double)  -- ^ scatter chain, over @y@
-  -> Concrete (TKS shOut Double)                         -- ^ the cotangent @y@
-  -> IO ()
-checkAdjoint name gatherChain src scatterChain y =
-  let gOut = interpretAstFull emptyEnv gatherChain
-      sOut = interpretAstFull emptyEnv scatterChain
-      lhs = unConcrete (sdot0 gOut y)
-      rhs = unConcrete (sdot0 src sOut)
-  in if abs (lhs - rhs) <= 1e-6 * (1 + abs lhs)
-     then pure ()
-     else error $ name ++ ": scatter is not the adjoint of gather: "
-                  ++ "<gather(x),y>=" ++ show lhs ++ " <x,scatter(y)>=" ++ show rhs
-
+-- | The full set of timing variants for the gradient with respect to the
+-- kernels, as described in the module haddock.
 benchesAt
   :: forall nImgs nCinp nCout nAh nAw nKh nKw.
      ( KnownNat nImgs, KnownNat nCinp, KnownNat nCout
@@ -88,51 +93,52 @@ benchesAt = do
       (arrB, _) =
         randomValue @(Concrete (TKS '[nImgs, nCout, nAh, nAw] Double))
                     0.5 seed3
-      f :: AstTensor AstMethodLet FullSpan (TKS '[nCout, nCinp, nKh, nKw] Double)
-        -> AstTensor AstMethodLet FullSpan (TKS '[nImgs, nCout, nAh, nAw] Double)
+      f :: AstTensor AstMethodLet FullSpan
+                     (TKS '[nCout, nCinp, nKh, nKw] Double)
+        -> AstTensor AstMethodLet FullSpan
+                     (TKS '[nImgs, nCout, nAh, nAw] Double)
       f k = conv2dPreservingS k (sconcrete (unConcrete arrA))
-      -- The handwritten gradient built as an AST term; constructing it
-      -- runs vectorization (sbuild at the AST target).
-      hTerm :: AstTensor AstMethodLet FullSpan (TKS '[nCout, nCinp, nKh, nKw] Double)
-      hTerm = conv2dPreserving_dKrn @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
-                              (sconcrete (unConcrete arrA))
-                              (sconcrete (unConcrete arrB))
-      hTermSimplified = simplifyInlineContract hTerm
-      -- The handwritten gradient with the incoming cotangent kept
-      -- as a variable, like in the artifact, so that simplification
-      -- can't constant-fold the cotangent side of the term.
+      -- The cotangent variable shared by the handwritten-term variants.
       varNameB = mkAstVarName (FTKS (knownShS @'[nImgs, nCout, nAh, nAw])
                                     (FTKScalar @Double))
                               (intToAstVarId 100000099)
-      hTermVar :: AstTensor AstMethodLet FullSpan (TKS '[nCout, nCinp, nKh, nKw] Double)
-      hTermVar = conv2dPreserving_dKrn @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
-                                 (sconcrete (unConcrete arrA))
-                                 (AstVar varNameB)
-      hTermVarSimplified = simplifyInlineContract hTermVar
       artifactRaw = vjpArtifact f arrK
       artifact = simplifyArtifactRev artifactRaw
+      -- The handwritten gradient built as an AST term — constructing it
+      -- runs vectorization (sbuild at the AST target) — with the incoming
+      -- cotangent kept as a variable, like in the artifact.
+      hTermVar :: AstTensor AstMethodLet FullSpan
+                            (TKS '[nCout, nCinp, nKh, nKw] Double)
+      hTermVar = conv2dPreserving_dKrn @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
+                                       (sconcrete (unConcrete arrA))
+                                       (AstVar varNameB)
+      hTermVarSimplified = simplifyInlineContract hTermVar
   -- Force the shared terms to WHNF (StrictData makes that a full build)
   -- before benchmarking the exec-only variants. WHNF suffices and avoids the
   -- string-formatting work of forcing via printArtifactSimple.
-  _ <- evaluate hTerm
-  _ <- evaluate hTermSimplified
-  _ <- evaluate hTermVarSimplified
-  _ <- evaluate artifact
   _ <- evaluate artifactRaw
+  _ <- evaluate artifact
+  _ <- evaluate hTermVar
+  _ <- evaluate hTermVarSimplified
   return
-    [ -- vjp per call, but with f and arrK fixed and only dt varying.
-      -- The artifact does not depend on dt, so full-laziness floats its
-      -- construction out of the timed loop: this secretly measures ~exec.
-      bench "S-fullpipe-hoisted" $ whnf
-        (\dt -> forceGrad $ vjp f arrK dt) arrB
-      -- vjp per call with the (per-call-varying) input baked into the
-      -- objective function, exactly as the tasty poor man's benchmark does.
-      -- Now the artifact genuinely depends on the varying input, so it is
-      -- rebuilt every iteration: this honestly measures the full pipeline.
-    , bench "S-fullpipe-honest" $ whnf
+    [ -- vjp per call with the (per-call-varying) input baked into the
+      -- objective function, exactly as the tasty poor man's benchmark does:
+      -- the artifact genuinely depends on the varying input, so it is
+      -- rebuilt every iteration and the full pipeline is honestly measured
+      -- (see 'pitfallBenches' for the hoisted variant that secretly isn't).
+      bench "S-fullpipe-honest" $ whnf
         (\a -> forceGrad
-               $ vjp (\k -> conv2dPreservingS k (sconcrete (unConcrete a))) arrK arrB)
+               $ vjp (\k -> conv2dPreservingS k (sconcrete (unConcrete a)))
+                     arrK arrB)
         arrA
+      -- The handwritten counterpart: build + vectorize + interpret per
+      -- call; like the tasty benchmark it mirrors, the cotangent is an
+      -- embedded constant and the term is never contracted.
+    , bench "H-fullpipe" $ whnf
+        (\b -> forceGrad $ interpretAstFull emptyEnv
+               $ conv2dPreserving_dKrn @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
+                                       (sconcrete (unConcrete arrA))
+                                       (sconcrete (unConcrete b))) arrB
       -- Building + simplifying the artifact only (the "compilation" cost),
       -- forced to WHNF as in mnistTrainBench2VTC (BenchMnistTools): with
       -- StrictData that suffices to force the build, and unlike forcing via
@@ -141,27 +147,31 @@ benchesAt = do
       -- argument so the body depends on it and criterion re-runs it per call.
     , bench "S-artifact" $ whnf
         (\k -> simplifyArtifactRev (vjpArtifact f k)) arrK
+      -- The handwritten counterpart: building + contracting the term only.
+    , bench "H-term" $ whnf
+        (\a -> simplifyInlineContract
+               $ conv2dPreserving_dKrn @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
+                                       (sconcrete (unConcrete a))
+                                       (AstVar varNameB)) arrA
     , bench "S-exec" $ whnf
         (\dt -> forceGrad
                   (vjpInterpretArtifact artifact arrK dt
                    :: Concrete (TKS '[nCout, nCinp, nKh, nKw] Double))) arrB
+      -- The handwritten counterpart: interpret the pre-built contracted
+      -- term, the cotangent bound in the environment like in the artifact.
+    , bench "H-exec" $ whnf
+        (\b -> forceGrad
+               $ interpretAstFull (extendEnv varNameB b emptyEnv)
+                                  hTermVarSimplified) arrB
     , bench "S-exec-raw" $ whnf
         (\dt -> forceGrad
                   (vjpInterpretArtifact artifactRaw arrK dt
                    :: Concrete (TKS '[nCout, nCinp, nKh, nKw] Double))) arrB
-    , bench "H-fullpipe" $ whnf
-        (\b -> forceGrad $ interpretAstFull emptyEnv
-                 $ conv2dPreserving_dKrn @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
-                                   (sconcrete (unConcrete arrA))
-                                   (sconcrete (unConcrete b))) arrB
-    , bench "H-exec" $ whnf
-        (\t -> forceGrad $ interpretAstFull emptyEnv t) hTerm
-    , bench "H-exec-contracted" $ whnf
-        (\t -> forceGrad $ interpretAstFull emptyEnv t) hTermSimplified
-    , bench "H-exec-var" $ whnf
+      -- The handwritten counterpart: interpret the uncontracted term.
+    , bench "H-exec-raw" $ whnf
         (\b -> forceGrad
                $ interpretAstFull (extendEnv varNameB b emptyEnv)
-                                  hTermVarSimplified) arrB
+                                  hTermVar) arrB
     ]
 
 -- | The full set of timing variants for the gradient with respect to the
@@ -182,69 +192,127 @@ benchesInpAt = do
         randomValue @(Concrete (TKS '[nImgs, nCout, nAh, nAw] Double))
                     0.5 seed3
       -- Differentiate with respect to the input, with the kernel baked in.
-      g :: AstTensor AstMethodLet FullSpan (TKS '[nImgs, nCinp, nAh, nAw] Double)
-        -> AstTensor AstMethodLet FullSpan (TKS '[nImgs, nCout, nAh, nAw] Double)
+      g :: AstTensor AstMethodLet FullSpan
+                     (TKS '[nImgs, nCinp, nAh, nAw] Double)
+        -> AstTensor AstMethodLet FullSpan
+                     (TKS '[nImgs, nCout, nAh, nAw] Double)
       g a = conv2dPreservingS (sconcrete (unConcrete arrK)) a
-      hTerm :: AstTensor AstMethodLet FullSpan (TKS '[nImgs, nCinp, nAh, nAw] Double)
-      hTerm = conv2dPreserving_dInp @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
-                              (sconcrete (unConcrete arrK))
-                              (sconcrete (unConcrete arrB))
-      hTermSimplified = simplifyInlineContract hTerm
       varNameB = mkAstVarName (FTKS (knownShS @'[nImgs, nCout, nAh, nAw])
                                     (FTKScalar @Double))
                               (intToAstVarId 100000099)
-      hTermVar :: AstTensor AstMethodLet FullSpan (TKS '[nImgs, nCinp, nAh, nAw] Double)
-      hTermVar = conv2dPreserving_dInp @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
-                                 (sconcrete (unConcrete arrK))
-                                 (AstVar varNameB)
-      hTermVarSimplified = simplifyInlineContract hTermVar
       artifactRaw = vjpArtifact g arrA
       artifact = simplifyArtifactRev artifactRaw
+      hTermVar :: AstTensor AstMethodLet FullSpan
+                            (TKS '[nImgs, nCinp, nAh, nAw] Double)
+      hTermVar = conv2dPreserving_dInp @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
+                                       (sconcrete (unConcrete arrK))
+                                       (AstVar varNameB)
+      hTermVarSimplified = simplifyInlineContract hTermVar
   -- Force to WHNF (a full build under StrictData) before benchmarking.
-  _ <- evaluate hTerm
-  _ <- evaluate hTermSimplified
-  _ <- evaluate hTermVarSimplified
-  _ <- evaluate artifact
   _ <- evaluate artifactRaw
+  _ <- evaluate artifact
+  _ <- evaluate hTermVar
+  _ <- evaluate hTermVarSimplified
+  -- The same variant pairs as in 'benchesAt', for dInp; see the comments
+  -- there.
   return
-    [ bench "S-fullpipe-hoisted" $ whnf
-        (\dt -> forceGrad $ vjp g arrA dt) arrB
-    , bench "S-fullpipe-honest" $ whnf
+    [ bench "S-fullpipe-honest" $ whnf
         (\k -> forceGrad
-               $ vjp (\a -> conv2dPreservingS (sconcrete (unConcrete k)) a) arrA arrB)
+               $ vjp (\a -> conv2dPreservingS (sconcrete (unConcrete k)) a)
+                     arrA arrB)
         arrK
-      -- Artifact build+simplify only, WHNF-forced; see 'benchesAt'.
+    , bench "H-fullpipe" $ whnf
+        (\b -> forceGrad $ interpretAstFull emptyEnv
+               $ conv2dPreserving_dInp @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
+                                       (sconcrete (unConcrete arrK))
+                                       (sconcrete (unConcrete b))) arrB
     , bench "S-artifact" $ whnf
         (\a -> simplifyArtifactRev (vjpArtifact g a)) arrA
+    , bench "H-term" $ whnf
+        (\k -> simplifyInlineContract
+               $ conv2dPreserving_dInp @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
+                                       (sconcrete (unConcrete k))
+                                       (AstVar varNameB)) arrK
     , bench "S-exec" $ whnf
         (\dt -> forceGrad
                   (vjpInterpretArtifact artifact arrA dt
                    :: Concrete (TKS '[nImgs, nCinp, nAh, nAw] Double))) arrB
+    , bench "H-exec" $ whnf
+        (\b -> forceGrad
+               $ interpretAstFull (extendEnv varNameB b emptyEnv)
+                                  hTermVarSimplified) arrB
     , bench "S-exec-raw" $ whnf
         (\dt -> forceGrad
                   (vjpInterpretArtifact artifactRaw arrA dt
                    :: Concrete (TKS '[nImgs, nCinp, nAh, nAw] Double))) arrB
-    , bench "H-fullpipe" $ whnf
-        (\b -> forceGrad $ interpretAstFull emptyEnv
-                 $ conv2dPreserving_dInp @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
-                                   (sconcrete (unConcrete arrK))
-                                   (sconcrete (unConcrete b))) arrB
-    , bench "H-exec" $ whnf
-        (\t -> forceGrad $ interpretAstFull emptyEnv t) hTerm
-    , bench "H-exec-contracted" $ whnf
-        (\t -> forceGrad $ interpretAstFull emptyEnv t) hTermSimplified
-    , bench "H-exec-var" $ whnf
+    , bench "H-exec-raw" $ whnf
         (\b -> forceGrad
                $ interpretAstFull (extendEnv varNameB b emptyEnv)
-                                  hTermVarSimplified) arrB
+                                  hTermVar) arrB
+    ]
+
+-- | The @S-*@ variants of 'benchesAt', but for a real (shaped) two-layer
+-- convolutional net (@convMnistTwoS@, each layer with maxpool), differentiated
+-- with respect to its full parameter tuple. The input image is embedded as a
+-- constant — a *random* one, since a constant broadcast folds the convolution
+-- gathers away — exactly as 'benchesAt' embeds the input in the
+-- conv2dPreserving objective. The objective is shared with @testCNNOPP2S@ via 'cnnObjective'.
+-- There are no @H-*@ variants, as there is no handwritten CNN gradient to
+-- compare against.
+benchesCnnAt
+  :: forall h w. (KnownNat h, KnownNat w, KnownNat (4 * Div h 4 * Div w 4))
+  => IO [Benchmark]
+benchesCnnAt = do
+  let (valsInit, seed2) =
+        randomValue @(MnistCnnShaped2.ADCnnMnistParametersShaped
+                        Concrete h w 2 3 4 5 Double)
+                    0.4 (mkStdGen 44)
+      (arrGlyph, seed3) =
+        randomValue @(Concrete (TKS '[7, 1, h, w] Double)) 0.5 seed2
+      (arrDt, _) =
+        randomValue @(Concrete (TKS '[SizeMnistLabel, 7] Double)) 0.5 seed3
+      valsInitT = toTarget @Concrete valsInit
+      -- Force the full parameter gradient (a tuple) by summing all leaves,
+      -- reusing forceGrad (unConcrete . ssum0) on each.
+      forceCnnGrad ((k1, b1), (k2, b2), (wd, bd), (wr, br)) =
+        forceGrad k1 + forceGrad b1 + forceGrad k2 + forceGrad b2
+        + forceGrad wd + forceGrad bd + forceGrad wr + forceGrad br
+      f = cnnObjective arrGlyph
+      artifactRaw = vjpArtifact f valsInit
+      artifact = simplifyArtifactRev artifactRaw
+  _ <- evaluate artifactRaw
+  _ <- evaluate artifact
+  return
+    [ bench "S-fullpipe-honest" $ whnf
+        (\glyph -> forceCnnGrad $ vjp (cnnObjective glyph) valsInit arrDt)
+        arrGlyph
+    , bench "S-artifact" $ whnf
+        (\v -> simplifyArtifactRev (vjpArtifact f v)) valsInit
+    , bench "S-exec" $ whnf
+        (\dt -> forceCnnGrad
+                  (vjpInterpretArtifact artifact valsInitT dt
+                   :: MnistCnnShaped2.ADCnnMnistParametersShaped
+                        Concrete h w 2 3 4 5 Double)) arrDt
+    , bench "S-exec-raw" $ whnf
+        (\dt -> forceCnnGrad
+                  (vjpInterpretArtifact artifactRaw valsInitT dt
+                   :: MnistCnnShaped2.ADCnnMnistParametersShaped
+                        Concrete h w 2 3 4 5 Double)) arrDt
     ]
 
 -- | Micro-benchmarks for the dominant cost found by profiling: the
--- interpreted im2col gather chains. Compares the AD-produced orientation
--- (large dim first in the gather output, small dims innermost in the
--- copied slices) against the vectorization-produced orientation
--- (small dim first, large dim innermost in slices), and both against
--- a single fused gather that avoids the intermediate array entirely.
+-- interpreted im2col gather chains. Four comparisons: (1) the
+-- AD-produced orientation (large dim first in the gather output, small
+-- dims innermost in the copied slices) vs the vectorization-produced
+-- one (small dim first, large dim innermost in slices); (2) the AD
+-- orientation vs its two candidate canonicalizations, shm dims sorted
+-- vs shn dims sorted; (3) both orientations vs a single fused gather
+-- that avoids the intermediate array entirely; (4) the fused gather vs
+-- itself with its shm dims sorted, ascending and descending — its shn,
+-- @[3, 3]@, is already sorted, fusion having consumed the large dims
+-- into the index function, so shm is the fused form's only sortable
+-- knob. interpretAstFull does not run contractAst, so each variant
+-- times exactly the orientation written.
 gatherBenches :: IO [Benchmark]
 gatherBenches = do
   let (arr1, seed2) =
@@ -253,105 +321,183 @@ gatherBenches = do
       (arr2, _) =
         randomValue @(Concrete (TKS '[50, 50, 3, 3] Double))
                     0.5 seed2
-      s1, s1' :: AstTensor AstMethodLet FullSpan (TKS '[50, 3, 3, 50] Double)
-      s1 = sconcrete (unConcrete arr1)
-      s1' = sconcrete (unConcrete arr1)
-      s2 :: AstTensor AstMethodLet FullSpan (TKS '[50, 50, 3, 3] Double)
-      s2 = sconcrete (unConcrete arr2)
-      -- S orientation: sgather @[48,3], big dim first.
-      twoS :: AstTensor AstMethodLet FullSpan (TKS '[48, 3, 3, 48, 3, 3] Double)
-      twoS =
+      src1, src1'
+        :: AstTensor AstMethodLet FullSpan (TKS '[50, 3, 3, 50] Double)
+      src1 = sconcrete (unConcrete arr1)
+      src1' = sconcrete (unConcrete arr1)
+      src2 :: AstTensor AstMethodLet FullSpan (TKS '[50, 50, 3, 3] Double)
+      src2 = sconcrete (unConcrete arr2)
+      -- The AD orientation: sgather @[48,3], big dim first.
+      twoAd :: AstTensor AstMethodLet FullSpan
+                        (TKS '[48, 3, 3, 48, 3, 3] Double)
+      twoAd =
         sgather @'[48, 3] @'[3, 48, 3, 3] @'[50]
                 (stranspose @'[4, 2, 0, 3, 1]
                    (sgather @'[48, 3] @'[3, 3, 50] @'[50]
-                            s1
+                            src1
                             (\case [a, b] -> [a + b]
-                                   _ -> error "twoS")))
+                                   _ -> error "twoAd")))
                 (\case [c, d] -> [c + d]
-                       _ -> error "twoS")
-      -- H orientation: sgather @[3,48], small dim first.
-      twoH :: AstTensor AstMethodLet FullSpan (TKS '[3, 48, 3, 3, 3, 48] Double)
-      twoH =
+                       _ -> error "twoAd")
+      -- The vectorization orientation: sgather @[3,48], small dim first.
+      twoVec :: AstTensor AstMethodLet FullSpan
+                        (TKS '[3, 48, 3, 3, 3, 48] Double)
+      twoVec =
         sgather @'[3, 48] @'[3, 3, 3, 48] @'[50]
                 (stranspose @'[4, 2, 0, 3, 1]
                    (sgather @'[3, 48] @'[3, 3, 50] @'[50]
-                            s1'
+                            src1'
                             (\case [b, a] -> [a + b]
-                                   _ -> error "twoH")))
+                                   _ -> error "twoVec")))
                 (\case [d, c] -> [c + d]
-                       _ -> error "twoH")
-      -- One fused gather, S orientation of the output dims.
-      fusedS :: AstTensor AstMethodLet FullSpan (TKS '[48, 3, 48, 3, 3, 3] Double)
-      fusedS =
-        sgather @'[48, 3, 48, 3] @'[3, 3] @'[50, 50]
-                s2
-                (\case [h, kh, w, kw] -> [h + kh, w + kw]
-                       _ -> error "fusedS")
-      -- One fused gather, H orientation of the output dims.
-      fusedH :: AstTensor AstMethodLet FullSpan (TKS '[3, 48, 3, 48, 3, 3] Double)
-      fusedH =
-        sgather @'[3, 48, 3, 48] @'[3, 3] @'[50, 50]
-                s2
-                (\case [kh, h, kw, w] -> [h + kh, w + kw]
-                       _ -> error "fusedH")
-      -- The S chain as the contemplated canonicalization rule would
-      -- rewrite it: each gather's shm dims sorted ascending, with a
-      -- compensating transpose above that restores the original dim order.
-      canonS :: AstTensor AstMethodLet FullSpan (TKS '[48, 3, 3, 48, 3, 3] Double)
-      canonS =
+                       _ -> error "twoVec")
+      -- The AD chain with each gather's shm dims sorted ascending and a
+      -- compensating transpose above that restores the original dim order —
+      -- a canonicalization considered for contractAst and refuted by this
+      -- measurement: the concrete gather's cost is per output position,
+      -- so reordering the shm dims changes nothing.
+      canonShm :: AstTensor AstMethodLet FullSpan
+                          (TKS '[48, 3, 3, 48, 3, 3] Double)
+      canonShm =
         stranspose @'[1, 0]
           (sgather @'[3, 48] @'[3, 48, 3, 3] @'[50]
                    (stranspose @'[4, 2, 0, 3, 1]
                       (stranspose @'[1, 0]
                          (sgather @'[3, 48] @'[3, 3, 50] @'[50]
-                                  s1
+                                  src1
                                   (\case [b, a] -> [a + b]
-                                         _ -> error "canonS"))))
+                                         _ -> error "canonShm"))))
                    (\case [d, c] -> [c + d]
-                          _ -> error "canonS"))
-      -- The S chain with the second gather's shn dims sorted ascending
+                          _ -> error "canonShm"))
+      -- The AD chain with the second gather's shn dims sorted ascending
       -- instead (large dims innermost in the copied slices), by a
       -- transpose below the gather (merges into the existing view)
-      -- and a compensating transpose above.
-      canonS2 :: AstTensor AstMethodLet FullSpan (TKS '[48, 3, 3, 48, 3, 3] Double)
-      canonS2 =
+      -- and a compensating transpose above — the rewrite the shn-sort
+      -- rule in contractAst now performs on such chains (the first
+      -- gather's shn is already sorted, so it is left alone).
+      canonShn :: AstTensor AstMethodLet FullSpan
+                           (TKS '[48, 3, 3, 48, 3, 3] Double)
+      canonShn =
         stranspose @'[0, 1, 2, 5, 3, 4]
           (sgather @'[48, 3] @'[3, 3, 3, 48] @'[50]
                    (stranspose @'[0, 1, 3, 4, 2]
                       (stranspose @'[4, 2, 0, 3, 1]
                          (sgather @'[48, 3] @'[3, 3, 50] @'[50]
-                                  s1
+                                  src1
                                   (\case [a, b] -> [a + b]
-                                         _ -> error "canonS2"))))
+                                         _ -> error "canonShn"))))
                    (\case [c, d] -> [c + d]
-                          _ -> error "canonS2"))
+                          _ -> error "canonShn"))
+      -- One fused gather, AD orientation of the output dims.
+      fusedAd :: AstTensor AstMethodLet FullSpan
+                          (TKS '[48, 3, 48, 3, 3, 3] Double)
+      fusedAd =
+        sgather @'[48, 3, 48, 3] @'[3, 3] @'[50, 50]
+                src2
+                (\case [h, kh, w, kw] -> [h + kh, w + kw]
+                       _ -> error "fusedAd")
+      -- One fused gather, vectorization orientation of the output dims.
+      fusedVec :: AstTensor AstMethodLet FullSpan
+                          (TKS '[3, 48, 3, 48, 3, 3] Double)
+      fusedVec =
+        sgather @'[3, 48, 3, 48] @'[3, 3] @'[50, 50]
+                src2
+                (\case [kh, h, kw, w] -> [h + kh, w + kw]
+                       _ -> error "fusedVec")
+      -- The fused gather with its shm dims sorted ascending and a
+      -- compensating transpose above restoring the AD output order.
+      -- Its shn is [3, 3] — already sorted, fusion having consumed the
+      -- large dims into the index function — so shm order is the only
+      -- sortable knob of the fused form; it is benchmarked in both
+      -- directions to record that sorting cannot rescue fusion: the
+      -- cost is per output position, and the position count is exactly
+      -- what fusion inflates.
+      fusedShmAsc :: AstTensor AstMethodLet FullSpan
+                              (TKS '[48, 3, 48, 3, 3, 3] Double)
+      fusedShmAsc =
+        stranspose @'[2, 0, 3, 1, 4, 5]
+          (sgather @'[3, 3, 48, 48] @'[3, 3] @'[50, 50]
+                   src2
+                   (\case [kh, kw, h, w] -> [h + kh, w + kw]
+                          _ -> error "fusedShmAsc"))
+      -- The same with the shm dims sorted descending.
+      fusedShmDesc :: AstTensor AstMethodLet FullSpan
+                               (TKS '[48, 3, 48, 3, 3, 3] Double)
+      fusedShmDesc =
+        stranspose @'[0, 2, 1, 3, 4, 5]
+          (sgather @'[48, 48, 3, 3] @'[3, 3] @'[50, 50]
+                   src2
+                   (\case [h, w, kh, kw] -> [h + kh, w + kw]
+                          _ -> error "fusedShmDesc"))
   -- Force to WHNF (a full build under StrictData) before benchmarking.
-  _ <- evaluate twoS
-  _ <- evaluate twoH
-  _ <- evaluate fusedS
-  _ <- evaluate fusedH
-  _ <- evaluate canonS
-  _ <- evaluate canonS2
+  _ <- evaluate twoAd
+  _ <- evaluate twoVec
+  _ <- evaluate canonShm
+  _ <- evaluate canonShn
+  _ <- evaluate fusedAd
+  _ <- evaluate fusedVec
+  _ <- evaluate fusedShmAsc
+  _ <- evaluate fusedShmDesc
   return
-    [ bench "two-gathers-S-orient" $ whnf
-        (\t -> forceGrad $ interpretAstFull emptyEnv t) twoS
-    , bench "two-gathers-H-orient" $ whnf
-        (\t -> forceGrad $ interpretAstFull emptyEnv t) twoH
-    , bench "two-gathers-S-canonicalized" $ whnf
-        (\t -> forceGrad $ interpretAstFull emptyEnv t) canonS
-    , bench "two-gathers-S-shn-sorted" $ whnf
-        (\t -> forceGrad $ interpretAstFull emptyEnv t) canonS2
-    , bench "fused-gather-S-orient" $ whnf
-        (\t -> forceGrad $ interpretAstFull emptyEnv t) fusedS
-    , bench "fused-gather-H-orient" $ whnf
-        (\t -> forceGrad $ interpretAstFull emptyEnv t) fusedH
+    [ bench "two-gathers-ad-orient" $ whnf
+        (\t -> forceGrad $ interpretAstFull emptyEnv t) twoAd
+    , bench "two-gathers-vec-orient" $ whnf
+        (\t -> forceGrad $ interpretAstFull emptyEnv t) twoVec
+    , bench "two-gathers-ad-shm-sorted" $ whnf
+        (\t -> forceGrad $ interpretAstFull emptyEnv t) canonShm
+    , bench "two-gathers-ad-shn-sorted" $ whnf
+        (\t -> forceGrad $ interpretAstFull emptyEnv t) canonShn
+    , bench "fused-gather-ad-orient" $ whnf
+        (\t -> forceGrad $ interpretAstFull emptyEnv t) fusedAd
+    , bench "fused-gather-vec-orient" $ whnf
+        (\t -> forceGrad $ interpretAstFull emptyEnv t) fusedVec
+    , bench "fused-gather-shm-sorted-asc" $ whnf
+        (\t -> forceGrad $ interpretAstFull emptyEnv t) fusedShmAsc
+    , bench "fused-gather-shm-sorted-desc" $ whnf
+        (\t -> forceGrad $ interpretAstFull emptyEnv t) fusedShmDesc
     ]
+
+-- | Verify that a hand-built scatter chain is the adjoint (transpose) of the
+-- corresponding gather chain, via the adjoint law that holds iff scatter is
+-- gather's transpose: for all index functions @f@, sources @x@ and
+-- cotangents @y@, @sdot0 (sgather x f) y == sdot0 x (sscatter y f)@. Errors
+-- loudly if the scatter chain was built with wrong shapes or index
+-- directions.
+checkAdjoint
+  :: (KnownShS shSrc, KnownShS shOut)
+  => String
+  -> AstTensor AstMethodLet FullSpan (TKS shOut Double)
+       -- ^ gather chain, over @src@
+  -> Concrete (TKS shSrc Double)
+       -- ^ the source @x@
+  -> AstTensor AstMethodLet FullSpan (TKS shSrc Double)
+       -- ^ scatter chain, over @y@
+  -> Concrete (TKS shOut Double)
+       -- ^ the cotangent @y@
+  -> IO ()
+checkAdjoint name gatherChain src scatterChain y =
+  let gOut = interpretAstFull emptyEnv gatherChain
+      sOut = interpretAstFull emptyEnv scatterChain
+      lhs = unConcrete (sdot0 gOut y)
+      rhs = unConcrete (sdot0 src sOut)
+  in if abs (lhs - rhs) <= 1e-6 * (1 + abs lhs)
+     then pure ()
+     else error $ name ++ ": scatter is not the adjoint of gather: "
+                  ++ "sdot0 (sgather x f) y=" ++ show lhs
+                  ++ " sdot0 x (sscatter y f)=" ++ show rhs
 
 -- | The scatter analogue of 'gatherBenches': the interpreted scatter chains
 -- that appear in the input-image gradient (the @sscatter@ path). Each chain
 -- is the exact adjoint (transpose) of the corresponding gather chain above —
 -- verified at startup by 'checkAdjoint' — so this isolates the scatter cost
--- the way 'gatherBenches' isolates the gather cost.
+-- the way 'gatherBenches' isolates the gather cost. The correspondence is
+-- deliberately partial. The shn-sorted chain's adjoint is included: it
+-- measures the ruling that the shn-sort must not be extended to scatter,
+-- a ~4x pessimization — scatter adds each slice as one flat vector, so a
+-- sorted shn has no per-shn-dim loop to amortize, while the compensating
+-- transposes leave the slice views strided. There are no shm-sorted or
+-- fused-sorted adjoints; they would only re-measure knobs 'gatherBenches'
+-- already shows dead.
 scatterBenches :: IO [Benchmark]
 scatterBenches = do
   let (arrX1, seedb) =
@@ -378,84 +524,180 @@ scatterBenches = do
       y3 = sconcrete (unConcrete arrY3)
       y4 :: AstTensor AstMethodLet FullSpan (TKS '[3, 48, 3, 48, 3, 3] Double)
       y4 = sconcrete (unConcrete arrY4)
-      -- The gather chains from 'gatherBenches' (over x1/x2), for verification.
-      gTwoS :: AstTensor AstMethodLet FullSpan (TKS '[48, 3, 3, 48, 3, 3] Double)
-      gTwoS =
+      -- The gather chains from 'gatherBenches', rebuilt over x1/x2 as
+      -- checkAdjoint fixtures only — benchmarked there, not here (gather
+      -- cost is structural, so timing these copies would just duplicate
+      -- those benches).
+      gTwoAd :: AstTensor AstMethodLet FullSpan
+                         (TKS '[48, 3, 3, 48, 3, 3] Double)
+      gTwoAd =
         sgather @'[48, 3] @'[3, 48, 3, 3] @'[50]
                 (stranspose @'[4, 2, 0, 3, 1]
                    (sgather @'[48, 3] @'[3, 3, 50] @'[50] x1
                             (\case [a, b] -> [a + b]
-                                   _ -> error "gTwoS")))
+                                   _ -> error "gTwoAd")))
                 (\case [c, d] -> [c + d]
-                       _ -> error "gTwoS")
-      gTwoH :: AstTensor AstMethodLet FullSpan (TKS '[3, 48, 3, 3, 3, 48] Double)
-      gTwoH =
+                       _ -> error "gTwoAd")
+      gTwoVec :: AstTensor AstMethodLet FullSpan
+                         (TKS '[3, 48, 3, 3, 3, 48] Double)
+      gTwoVec =
         sgather @'[3, 48] @'[3, 3, 3, 48] @'[50]
                 (stranspose @'[4, 2, 0, 3, 1]
                    (sgather @'[3, 48] @'[3, 3, 50] @'[50] x1
                             (\case [b, a] -> [a + b]
-                                   _ -> error "gTwoH")))
+                                   _ -> error "gTwoVec")))
                 (\case [d, c] -> [c + d]
-                       _ -> error "gTwoH")
-      gFusedS :: AstTensor AstMethodLet FullSpan (TKS '[48, 3, 48, 3, 3, 3] Double)
-      gFusedS =
+                       _ -> error "gTwoVec")
+      gCanonShn :: AstTensor AstMethodLet FullSpan
+                            (TKS '[48, 3, 3, 48, 3, 3] Double)
+      gCanonShn =
+        stranspose @'[0, 1, 2, 5, 3, 4]
+          (sgather @'[48, 3] @'[3, 3, 3, 48] @'[50]
+                   (stranspose @'[0, 1, 3, 4, 2]
+                      (stranspose @'[4, 2, 0, 3, 1]
+                         (sgather @'[48, 3] @'[3, 3, 50] @'[50]
+                                  x1
+                                  (\case [a, b] -> [a + b]
+                                         _ -> error "gCanonShn"))))
+                   (\case [c, d] -> [c + d]
+                          _ -> error "gCanonShn"))
+      gFusedAd :: AstTensor AstMethodLet FullSpan
+                           (TKS '[48, 3, 48, 3, 3, 3] Double)
+      gFusedAd =
         sgather @'[48, 3, 48, 3] @'[3, 3] @'[50, 50] x2
                 (\case [h, kh, w, kw] -> [h + kh, w + kw]
-                       _ -> error "gFusedS")
-      gFusedH :: AstTensor AstMethodLet FullSpan (TKS '[3, 48, 3, 48, 3, 3] Double)
-      gFusedH =
+                       _ -> error "gFusedAd")
+      gFusedVec :: AstTensor AstMethodLet FullSpan
+                           (TKS '[3, 48, 3, 48, 3, 3] Double)
+      gFusedVec =
         sgather @'[3, 48, 3, 48] @'[3, 3] @'[50, 50] x2
                 (\case [kh, h, kw, w] -> [h + kh, w + kw]
-                       _ -> error "gFusedH")
+                       _ -> error "gFusedVec")
       -- The scatter chains: exact adjoints of the gather chains above.
       -- The two-op chains reverse the composition order and invert the
       -- connecting transpose (@[4,2,0,3,1]@ becomes @[2,4,1,3,0]@).
-      twoScatterS :: AstTensor AstMethodLet FullSpan (TKS '[50, 3, 3, 50] Double)
-      twoScatterS =
+      twoScatterAd :: AstTensor AstMethodLet FullSpan
+                               (TKS '[50, 3, 3, 50] Double)
+      twoScatterAd =
         sscatter @'[48, 3] @'[3, 3, 50] @'[50]
                  (stranspose @'[2, 4, 1, 3, 0]
                     (sscatter @'[48, 3] @'[3, 48, 3, 3] @'[50] y1
                               (\case [c, d] -> [c + d]
-                                     _ -> error "twoScatterS")))
+                                     _ -> error "twoScatterAd")))
                  (\case [a, b] -> [a + b]
-                        _ -> error "twoScatterS")
-      twoScatterH :: AstTensor AstMethodLet FullSpan (TKS '[50, 3, 3, 50] Double)
-      twoScatterH =
+                        _ -> error "twoScatterAd")
+      twoScatterVec :: AstTensor AstMethodLet FullSpan
+                               (TKS '[50, 3, 3, 50] Double)
+      twoScatterVec =
         sscatter @'[3, 48] @'[3, 3, 50] @'[50]
                  (stranspose @'[2, 4, 1, 3, 0]
                     (sscatter @'[3, 48] @'[3, 3, 3, 48] @'[50] y2
                               (\case [d, c] -> [c + d]
-                                     _ -> error "twoScatterH")))
+                                     _ -> error "twoScatterVec")))
                  (\case [b, a] -> [a + b]
-                        _ -> error "twoScatterH")
-      fusedScatterS :: AstTensor AstMethodLet FullSpan (TKS '[50, 50, 3, 3] Double)
-      fusedScatterS =
+                        _ -> error "twoScatterVec")
+      -- The adjoint of the shn-sorted chain ('canonShn' in 'gatherBenches'),
+      -- on the same cotangent as twoScatterAd: the measured ~4x
+      -- pessimization that rules out extending the shn-sort to scatter,
+      -- strengthening the ruling from "cannot pay" to "loses outright" —
+      -- mechanism in the 'scatterBenches' haddock above.
+      twoScatterShnSorted :: AstTensor AstMethodLet FullSpan
+                                       (TKS '[50, 3, 3, 50] Double)
+      twoScatterShnSorted =
+        sscatter @'[48, 3] @'[3, 3, 50] @'[50]
+                 (stranspose @'[2, 4, 1, 3, 0]
+                    (stranspose @'[0, 1, 4, 2, 3]
+                       (sscatter @'[48, 3] @'[3, 3, 3, 48] @'[50]
+                                 (stranspose @'[0, 1, 2, 4, 5, 3] y1)
+                                 (\case [c, d] -> [c + d]
+                                        _ -> error "twoScatterShnSorted"))))
+                 (\case [a, b] -> [a + b]
+                        _ -> error "twoScatterShnSorted")
+      fusedScatterAd :: AstTensor AstMethodLet FullSpan
+                                 (TKS '[50, 50, 3, 3] Double)
+      fusedScatterAd =
         sscatter @'[48, 3, 48, 3] @'[3, 3] @'[50, 50] y3
                  (\case [h, kh, w, kw] -> [h + kh, w + kw]
-                        _ -> error "fusedScatterS")
-      fusedScatterH :: AstTensor AstMethodLet FullSpan (TKS '[50, 50, 3, 3] Double)
-      fusedScatterH =
+                        _ -> error "fusedScatterAd")
+      fusedScatterVec :: AstTensor AstMethodLet FullSpan
+                                 (TKS '[50, 50, 3, 3] Double)
+      fusedScatterVec =
         sscatter @'[3, 48, 3, 48] @'[3, 3] @'[50, 50] y4
                  (\case [kh, h, kw, w] -> [h + kh, w + kw]
-                        _ -> error "fusedScatterH")
-  checkAdjoint "two-scatters-S-orient" gTwoS arrX1 twoScatterS arrY1
-  checkAdjoint "two-scatters-H-orient" gTwoH arrX1 twoScatterH arrY2
-  checkAdjoint "fused-scatter-S-orient" gFusedS arrX2 fusedScatterS arrY3
-  checkAdjoint "fused-scatter-H-orient" gFusedH arrX2 fusedScatterH arrY4
+                        _ -> error "fusedScatterVec")
+  checkAdjoint "two-scatters-ad-orient" gTwoAd arrX1 twoScatterAd arrY1
+  checkAdjoint "two-scatters-vec-orient" gTwoVec arrX1 twoScatterVec arrY2
+  checkAdjoint "two-scatters-ad-shn-sorted"
+               gCanonShn arrX1 twoScatterShnSorted arrY1
+  checkAdjoint "fused-scatter-ad-orient" gFusedAd arrX2 fusedScatterAd arrY3
+  checkAdjoint "fused-scatter-vec-orient" gFusedVec arrX2 fusedScatterVec arrY4
   -- Force to WHNF (a full build under StrictData) before benchmarking.
-  _ <- evaluate twoScatterS
-  _ <- evaluate twoScatterH
-  _ <- evaluate fusedScatterS
-  _ <- evaluate fusedScatterH
+  _ <- evaluate twoScatterAd
+  _ <- evaluate twoScatterVec
+  _ <- evaluate twoScatterShnSorted
+  _ <- evaluate fusedScatterAd
+  _ <- evaluate fusedScatterVec
   return
-    [ bench "two-scatters-S-orient" $ whnf
-        (\t -> forceGrad $ interpretAstFull emptyEnv t) twoScatterS
-    , bench "two-scatters-H-orient" $ whnf
-        (\t -> forceGrad $ interpretAstFull emptyEnv t) twoScatterH
-    , bench "fused-scatter-S-orient" $ whnf
-        (\t -> forceGrad $ interpretAstFull emptyEnv t) fusedScatterS
-    , bench "fused-scatter-H-orient" $ whnf
-        (\t -> forceGrad $ interpretAstFull emptyEnv t) fusedScatterH
+    [ bench "two-scatters-ad-orient" $ whnf
+        (\t -> forceGrad $ interpretAstFull emptyEnv t) twoScatterAd
+    , bench "two-scatters-vec-orient" $ whnf
+        (\t -> forceGrad $ interpretAstFull emptyEnv t) twoScatterVec
+    , bench "two-scatters-ad-shn-sorted" $ whnf
+        (\t -> forceGrad $ interpretAstFull emptyEnv t) twoScatterShnSorted
+    , bench "fused-scatter-ad-orient" $ whnf
+        (\t -> forceGrad $ interpretAstFull emptyEnv t) fusedScatterAd
+    , bench "fused-scatter-vec-orient" $ whnf
+        (\t -> forceGrad $ interpretAstFull emptyEnv t) fusedScatterVec
+    ]
+
+-- | The suite's single recorder of each known benchmarking pitfall, one
+-- variant at one size apiece, kept out of the sweep groups so those
+-- contain only honest, pairwise-comparable variants. The data matches
+-- the corresponding 'benchesAt' group (same seed chain), so each bench
+-- is directly comparable against its honest counterparts there.
+pitfallBenches :: IO [Benchmark]
+pitfallBenches = do
+  let -- The dKrn data of 'benchesAt'; the kernel shape is size-independent,
+      -- so seed2 continues both the 6x6 and the 48x48 chain.
+      (arrK, seed2) =
+        randomValue @(Concrete (TKS '[3, 3, 3, 3] Double)) 0.5 (mkStdGen 42)
+      (arrA6, seed3) =
+        randomValue @(Concrete (TKS '[3, 3, 6, 6] Double)) 0.5 seed2
+      (arrB6, _) =
+        randomValue @(Concrete (TKS '[3, 3, 6, 6] Double)) 0.5 seed3
+      (arrA48, seed3') =
+        randomValue @(Concrete (TKS '[3, 3, 48, 48] Double)) 0.5 seed2
+      (arrB48, _) =
+        randomValue @(Concrete (TKS '[3, 3, 48, 48] Double)) 0.5 seed3'
+      f6 :: AstTensor AstMethodLet FullSpan (TKS '[3, 3, 3, 3] Double)
+         -> AstTensor AstMethodLet FullSpan (TKS '[3, 3, 6, 6] Double)
+      f6 k = conv2dPreservingS k (sconcrete (unConcrete arrA6))
+      -- The handwritten term with the cotangent embedded as a constant,
+      -- as in the term the tasty poor man's benchmark interprets.
+      hTermConst :: AstTensor AstMethodLet FullSpan (TKS '[3, 3, 3, 3] Double)
+      hTermConst = conv2dPreserving_dKrn @3 @3 @3 @48 @48 @3 @3
+                                         (sconcrete (unConcrete arrA48))
+                                         (sconcrete (unConcrete arrB48))
+      hTermConstSimplified = simplifyInlineContract hTermConst
+  -- Force to WHNF (a full build under StrictData) before benchmarking.
+  _ <- evaluate hTermConstSimplified
+  return
+    [ -- vjp per call, but with the objective and its input fixed and only
+      -- the cotangent varying. The artifact does not depend on the
+      -- cotangent, so full laziness floats its construction out of the
+      -- timed loop and the artifact tax — the bulk of an honest 6x6 call —
+      -- goes unmeasured. Compare against S-fullpipe-honest (the tax
+      -- included) and S-exec in the 6x6 group.
+      bench "S-fullpipe-hoisted-6x6" $ whnf
+        (\dt -> forceGrad $ vjp f6 arrK dt) arrB6
+      -- As H-exec in the 48x48 group, but with the cotangent embedded as
+      -- a random concrete constant. Records that the embedding is
+      -- harmless: this measures the same as H-exec, i.e., simplification
+      -- does not constant-fold a random embedded constant through the
+      -- gathers — a broadcast constant it would fold, which is why
+      -- benchmark inputs are random.
+    , bench "H-exec-const-48x48" $ whnf
+        (\t -> forceGrad $ interpretAstFull emptyEnv t) hTermConstSimplified
     ]
 
 -- | Print the two gradient programs being compared instead of benchmarking,
@@ -475,22 +717,26 @@ printTerms = do
       (arrB, _) =
         randomValue @(Concrete (TKS '[nImgs, nCout, nAh, nAw] Double))
                     0.5 seed3
-      f :: AstTensor AstMethodLet FullSpan (TKS '[nCout, nCinp, nKh, nKw] Double)
-        -> AstTensor AstMethodLet FullSpan (TKS '[nImgs, nCout, nAh, nAw] Double)
+      f :: AstTensor AstMethodLet FullSpan
+                     (TKS '[nCout, nCinp, nKh, nKw] Double)
+        -> AstTensor AstMethodLet FullSpan
+                     (TKS '[nImgs, nCout, nAh, nAw] Double)
       f k = conv2dPreservingS k (sconcrete (unConcrete arrA))
-      hTerm :: AstTensor AstMethodLet FullSpan (TKS '[nCout, nCinp, nKh, nKw] Double)
+      artifact = simplifyArtifactRev (vjpArtifact f arrK)
+      hTerm :: AstTensor AstMethodLet FullSpan
+                         (TKS '[nCout, nCinp, nKh, nKw] Double)
       hTerm = conv2dPreserving_dKrn @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
-                              (sconcrete (unConcrete arrA))
-                              (sconcrete (unConcrete arrB))
+                                    (sconcrete (unConcrete arrA))
+                                    (sconcrete (unConcrete arrB))
       hTermSimplified = simplifyInlineContract hTerm
       varNameB = mkAstVarName (FTKS (knownShS @'[nImgs, nCout, nAh, nAw])
                                     (FTKScalar @Double))
                               (intToAstVarId 100000099)
-      hTermVar :: AstTensor AstMethodLet FullSpan (TKS '[nCout, nCinp, nKh, nKw] Double)
+      hTermVar :: AstTensor AstMethodLet FullSpan
+                            (TKS '[nCout, nCinp, nKh, nKw] Double)
       hTermVar = conv2dPreserving_dKrn @nImgs @nCinp @nCout @nAh @nAw @nKh @nKw
-                                 (sconcrete (unConcrete arrA))
-                                 (AstVar varNameB)
-      artifact = simplifyArtifactRev (vjpArtifact f arrK)
+                                       (sconcrete (unConcrete arrA))
+                                       (AstVar varNameB)
   putStrLn "=== S: simplified artifact (derivative) ==="
   putStrLn $ printArtifactPretty artifact
   putStrLn "=== H: contracted handwritten-vectorized term ==="
@@ -514,8 +760,12 @@ main = do
       i48 <- benchesInpAt @3 @3 @3 @48 @48 @3 @3
       i96 <- benchesInpAt @3 @3 @3 @96 @96 @3 @3
       i192 <- benchesInpAt @3 @3 @3 @192 @192 @3 @3
+      cnn6 <- benchesCnnAt @6 @6
+      cnn12 <- benchesCnnAt @12 @12
+      cnn24 <- benchesCnnAt @24 @24
       bg <- gatherBenches
       bs <- scatterBenches
+      pf <- pitfallBenches
       defaultMain
         [ bgroup "6x6" b6
         , bgroup "24x24" b24
@@ -527,6 +777,10 @@ main = do
         , bgroup "inp-48x48" i48
         , bgroup "inp-96x96" i96
         , bgroup "inp-192x192" i192
+        , bgroup "cnn-6x6" cnn6
+        , bgroup "cnn-12x12" cnn12
+        , bgroup "cnn-24x24" cnn24
         , bgroup "gather48" bg
         , bgroup "scatter48" bs
+        , bgroup "pitfalls" pf
         ]

--- a/example/MnistCnnRanked2.hs
+++ b/example/MnistCnnRanked2.hs
@@ -58,7 +58,7 @@ convMnistLayerR
   -> target (TKR 4 r)  -- ^ @[batch_size, c_out, h \`Div\` 2, w \`Div\` 2]@
 convMnistLayerR ker input bias =
   let (batch_size :$: _ :$: h :$: w :$: ZSR) = rshape input
-      yConv = conv2dSame ker input
+      yConv = conv2dPreserving ker input
       biasStretched = rtranspose [0, 3, 1, 2]
                       $ rreplicate batch_size $ rreplicate h $ rreplicate w bias
       yRelu = relu $ yConv + biasStretched

--- a/example/MnistCnnShaped2.hs
+++ b/example/MnistCnnShaped2.hs
@@ -55,7 +55,7 @@ convMnistLayerS
   -> target (TKS '[batch_size, c_out, h `Div` 2, w `Div` 2] r)
 convMnistLayerS SNat SNat SNat SNat SNat SNat SNat
                 ker input bias =
-  let yConv = conv2dSameS ker input
+  let yConv = conv2dPreservingS ker input
       biasStretched = stranspose @'[0, 3, 1, 2]
                       $ sreplicate {-@batch_size-}
                       $ sreplicate {-@h-}

--- a/horde-ad.cabal
+++ b/horde-ad.cabal
@@ -347,6 +347,7 @@ benchmark convVjpBench
     build-depends:
       , horde-ad:horde-ad
       , horde-ad:testCommonLibrary
+      , horde-ad:exampleLibrary
 
       , base
       , criterion

--- a/src/HordeAd/Core/AstInline.hs
+++ b/src/HordeAd/Core/AstInline.hs
@@ -170,7 +170,7 @@ inlineAst c !memo v0 = case v0 of
   -- occurrences, but only dynamic occurrences. Tensor expressions
   -- in conditionals are problematic and special enough
   -- that we can let it be until problems are encountered in the wild.
-  -- See https://github.com/VMatthijs/CHAD/blob/main/src/Count.hs#L88-L152.
+  -- See https://github.com/VMatthijs/CHAD/blob/755fc47e1f8d1c3d91455f123338f44a353fc265/src/Count.hs#L88-L152.
   Ast.AstCondK b a2 a3 ->
     let (memoA2, t2) = inlineAst c memo a2
         (memoA3, t3) = inlineAst c memo a3

--- a/src/HordeAd/External/CommonRankedOps.hs
+++ b/src/HordeAd/External/CommonRankedOps.hs
@@ -149,10 +149,10 @@ softMax1 d =
 --
 -- BTW, the indexing lower bounds in the code are spurious,
 -- so they get simplified away in the resulting AST program.
-conv2dSame
+conv2dPreserving
   :: (ADReady target, NumScalar r)
   => target (TKR 4 r) -> target (TKR 4 r) -> target (TKR 4 r)
-conv2dSame arrK arrA =
+conv2dPreserving arrK arrA =
   let [nImgs, nCinpA, nAh, nAw] = rshape arrA
       [nCout, nCinpK, nKh, nKw] = rshape arrK
       nCinp = assert (nCinpA == nCinpK `blame` (nCinpA, nCinpK)) nCinpA
@@ -163,7 +163,7 @@ conv2dSame arrK arrA =
       let arrAt = slicez shK1 arrA [iImg, 0, iBh, iBw]
           arrKt = slicez shK1 arrK [iCout, 0, 0, 0]
       in rfromK $ rdot0 arrAt arrKt
-    _ -> error "conv2dSame: impossible pattern needlessly required"
+    _ -> error "conv2dPreserving: impossible pattern needlessly required"
 
 -- | Full convolution with only enough padding to ensure all output points
 -- are affected by the same number of input points,

--- a/src/HordeAd/External/CommonShapedOps.hs
+++ b/src/HordeAd/External/CommonShapedOps.hs
@@ -133,7 +133,7 @@ softMax1S d =
 
 -- | Full convolution, where the output image size is the same
 -- as the input size.
-conv2dSameS
+conv2dPreservingS
   :: forall nImgs nCinp nCinpA nCout nAh nAw nKh nKw shK shA shB shK1
             target r.
      ( KnownNat nImgs, KnownNat nCinp, KnownNat nCout
@@ -146,7 +146,7 @@ conv2dSameS
      , shK1 ~ '[1, nCinpA, nKh, nKw]
      )
   => target (TKS shK r) -> target (TKS shA r) -> target (TKS shB r)
-conv2dSameS arrK arrA =
+conv2dPreservingS arrK arrA =
   kbuild $ \case
     [iImg, iCout, iBh, iBw] ->
       let arrAt = slicezS @shK1 arrA
@@ -154,7 +154,7 @@ conv2dSameS arrK arrA =
           arrKt = slicezS arrK
                           [iCout, 0, 0, 0]
       in sdot0 arrAt arrKt
-    _ -> error "conv2dSameS: impossible pattern needlessly required"
+    _ -> error "conv2dPreservingS: impossible pattern needlessly required"
 
 -- | Full convolution with only enough padding to ensure all output points
 -- are affected by the same number of input points,

--- a/test/simplified/TestConvCorrect.hs
+++ b/test/simplified/TestConvCorrect.hs
@@ -5,14 +5,14 @@
 -- AD derivatives, at the poor man's benchmark data and sizes.
 --
 -- These are the deterministic counterpart of the convolution poor man's
--- benchmarks in "TestConvQuickCheck": they check, on data of the same shapes
--- and sizes, that the symbolic gradient those poor man's benchmarks time is
--- also correct. They live in a separate module so that the whole testsuite's
--- non-QuickCheck tests, whose timing is much more deterministic, can be
--- compared in isolation from the randomized QuickCheck tests and poor man's
--- benchmarks. The poor man's benchmarks these mirror, the shared random-data
--- helpers (@benchData@ etc.) and the handwritten gradients they check against
--- all live in "TestConvQuickCheck".
+-- benchmarks in "TestConvQuickCheck": on data of the same shapes and sizes
+-- (the shared @benchData@ etc. helpers), they check that the gradient
+-- programs those benchmarks and bench/ConvVjpBench.hs time — the symbolic
+-- gradient and the handwritten term vectorized and interpreted — agree
+-- with the handwritten gradients evaluated at the Concrete target, all
+-- imported from that module. They live in a separate module so that
+-- the whole testsuite's non-QuickCheck tests, whose timing is much more
+-- deterministic, can be compared in isolation.
 module TestConvCorrect (testTrees) where
 
 import Prelude
@@ -21,39 +21,67 @@ import GHC.TypeLits (KnownNat, type (+), type (<=))
 import Test.Tasty
 import Test.Tasty.HUnit hiding (assert)
 
+import Data.Array.Nested.Shaped.Shape (knownShS)
+
 import HordeAd
+import HordeAd.Core.AstEnv (emptyEnv, extendEnv)
+import HordeAd.Core.AstInterpret (interpretAstFull)
 
 import EqEpsilon
 
 import TestConvQuickCheck
-  ( benchData, benchDataShrinking, benchDataPadded
-  , conv2dPreserving_dKrn, conv2dPreserving_dInp
-  , conv2dShrinking_dKrn, conv2dShrinking_dInp
-  , conv2dPadded_dKrn, conv2dPadded_dInp )
+  ( benchData
+  , benchDataPadded
+  , benchDataShrinking
+  , conv2dPadded_dInp
+  , conv2dPadded_dKrn
+  , conv2dPreserving_dInp
+  , conv2dPreserving_dKrn
+  , conv2dShrinking_dInp
+  , conv2dShrinking_dKrn
+  )
 
 testTrees :: [TestTree]
 testTrees =
   -- Gradient-correctness checks at the convolution poor man's benchmark data
-  -- and sizes from "TestConvQuickCheck": on data of those shapes, the symbolic
-  -- gradient must agree with the handwritten one — and, at the small size,
-  -- with the concrete non-symbolic AD too — so the path those poor man's
-  -- benchmarks time is verified correct at scale, not only timed.
+  -- and sizes from "TestConvQuickCheck": on data of those shapes, the
+  -- symbolic gradient and the vectorized-and-interpreted handwritten term
+  -- must agree with the handwritten gradient — and, at the small size, the
+  -- concrete non-symbolic AD and the variable-cotangent term must too — so
+  -- every path those poor man's benchmarks and bench/ConvVjpBench.hs time
+  -- is verified correct at scale, not only timed.
   -- Preserving convolution: input and output the same size.
-  [ testCase "conv2dPreservingVjp dKrn correct 6" (conv2dPreservingVjpKrnCorrect @6)
-  , testCase "conv2dPreservingVjp dKrn correct 24" (conv2dPreservingVjpKrnCorrect @24)
-  , testCase "conv2dPreservingVjp dKrn correct 96" (conv2dPreservingVjpKrnCorrect @96)
-  , testCase "conv2dPreservingVjp dInp correct 6" (conv2dPreservingVjpInpCorrect @6)
-  , testCase "conv2dPreservingVjp dInp correct 24" (conv2dPreservingVjpInpCorrect @24)
-  , testCase "conv2dPreservingVjp dInp correct 96" (conv2dPreservingVjpInpCorrect @96)
-  , testCase "conv2dPreservingVjp correct vs concrete 6" conv2dPreservingVjpConcrete6
+  [ testCase "conv2dPreservingVjp dKrn correct 6"
+             (conv2dPreservingVjpKrnCorrect @6)
+  , testCase "conv2dPreservingVjp dKrn correct 24"
+             (conv2dPreservingVjpKrnCorrect @24)
+  , testCase "conv2dPreservingVjp dKrn correct 96"
+             (conv2dPreservingVjpKrnCorrect @96)
+  , testCase "conv2dPreservingVjp dInp correct 6"
+             (conv2dPreservingVjpInpCorrect @6)
+  , testCase "conv2dPreservingVjp dInp correct 24"
+             (conv2dPreservingVjpInpCorrect @24)
+  , testCase "conv2dPreservingVjp dInp correct 96"
+             (conv2dPreservingVjpInpCorrect @96)
+  , testCase "conv2dPreservingVjp correct vs concrete 6"
+             conv2dPreservingVjpConcrete6
+  , testCase "conv2dPreservingVjp correct var cotangent 6"
+             conv2dPreservingVjpVarCotangent6
   -- Shrinking convolution: input larger than output.
-  , testCase "conv2dShrinkingVjp dKrn correct 6" (conv2dShrinkingVjpKrnCorrect @6)
-  , testCase "conv2dShrinkingVjp dKrn correct 24" (conv2dShrinkingVjpKrnCorrect @24)
-  , testCase "conv2dShrinkingVjp dKrn correct 96" (conv2dShrinkingVjpKrnCorrect @96)
-  , testCase "conv2dShrinkingVjp dInp correct 6" (conv2dShrinkingVjpInpCorrect @6)
-  , testCase "conv2dShrinkingVjp dInp correct 24" (conv2dShrinkingVjpInpCorrect @24)
-  , testCase "conv2dShrinkingVjp dInp correct 96" (conv2dShrinkingVjpInpCorrect @96)
-  , testCase "conv2dShrinkingVjp correct vs concrete 6" conv2dShrinkingVjpConcrete6
+  , testCase "conv2dShrinkingVjp dKrn correct 6"
+             (conv2dShrinkingVjpKrnCorrect @6)
+  , testCase "conv2dShrinkingVjp dKrn correct 24"
+             (conv2dShrinkingVjpKrnCorrect @24)
+  , testCase "conv2dShrinkingVjp dKrn correct 96"
+             (conv2dShrinkingVjpKrnCorrect @96)
+  , testCase "conv2dShrinkingVjp dInp correct 6"
+             (conv2dShrinkingVjpInpCorrect @6)
+  , testCase "conv2dShrinkingVjp dInp correct 24"
+             (conv2dShrinkingVjpInpCorrect @24)
+  , testCase "conv2dShrinkingVjp dInp correct 96"
+             (conv2dShrinkingVjpInpCorrect @96)
+  , testCase "conv2dShrinkingVjp correct vs concrete 6"
+             conv2dShrinkingVjpConcrete6
   -- Padded convolution: output larger than input.
   , testCase "conv2dPaddedVjp dKrn correct 6" (conv2dPaddedVjpKrnCorrect @6)
   , testCase "conv2dPaddedVjp dKrn correct 24" (conv2dPaddedVjpKrnCorrect @24)
@@ -70,24 +98,39 @@ testTrees =
 conv2dPreservingVjpKrnCorrect :: forall nAw. KnownNat nAw => Assertion
 conv2dPreservingVjpKrnCorrect =
   let (arrK, arrA, arrB) = benchData @nAw @Double 42
-      handwritten, symbolic :: Concrete (TKS '[3, 3, 3, 3] Double)
+      handwritten, symbolic, vectorized :: Concrete (TKS '[3, 3, 3, 3] Double)
       handwritten = conv2dPreserving_dKrn @3 @3 @3 @nAw @nAw @3 @3
-                                    (sconcrete (unConcrete arrA))
-                                    (sconcrete (unConcrete arrB))
+                                          (sconcrete (unConcrete arrA))
+                                          (sconcrete (unConcrete arrB))
       symbolic = vjp (`conv2dPreservingS` sconcrete (unConcrete arrA))
                      (sconcrete (unConcrete arrK)) (sconcrete (unConcrete arrB))
-  in assertEqualUpToEpsilon 1e-5 handwritten symbolic
+      -- The same handwritten gradient built at the AST target, vectorized
+      -- and interpreted — the computation the HandwrittenVectorized poor
+      -- man's benchmarks and the H- variants of bench/ConvVjpBench.hs
+      -- time; here its value is pinned to the Concrete-target one.
+      vectorized = interpretAstFull emptyEnv
+                   $ conv2dPreserving_dKrn @3 @3 @3 @nAw @nAw @3 @3
+                                           (sconcrete (unConcrete arrA))
+                                           (sconcrete (unConcrete arrB))
+  in do assertEqualUpToEpsilon 1e-5 handwritten symbolic
+        assertEqualUpToEpsilon 1e-5 handwritten vectorized
 
 conv2dPreservingVjpInpCorrect :: forall nAw. KnownNat nAw => Assertion
 conv2dPreservingVjpInpCorrect =
   let (arrK, arrA, arrB) = benchData @nAw @Double 42
-      handwritten, symbolic :: Concrete (TKS '[3, 3, nAw, nAw] Double)
+      handwritten, symbolic, vectorized
+        :: Concrete (TKS '[3, 3, nAw, nAw] Double)
       handwritten = conv2dPreserving_dInp @3 @3 @3 @nAw @nAw @3 @3
-                                    (sconcrete (unConcrete arrK))
-                                    (sconcrete (unConcrete arrB))
+                                          (sconcrete (unConcrete arrK))
+                                          (sconcrete (unConcrete arrB))
       symbolic = vjp (conv2dPreservingS (sconcrete (unConcrete arrK)))
                      (sconcrete (unConcrete arrA)) (sconcrete (unConcrete arrB))
-  in assertEqualUpToEpsilon 1e-5 handwritten symbolic
+      vectorized = interpretAstFull emptyEnv
+                   $ conv2dPreserving_dInp @3 @3 @3 @nAw @nAw @3 @3
+                                           (sconcrete (unConcrete arrK))
+                                           (sconcrete (unConcrete arrB))
+  in do assertEqualUpToEpsilon 1e-5 handwritten symbolic
+        assertEqualUpToEpsilon 1e-5 handwritten vectorized
 
 -- At the small size, also check the symbolic gradient against the concrete
 -- (non-symbolic) AD, which is too slow to run at the larger sizes.
@@ -96,54 +139,111 @@ conv2dPreservingVjpConcrete6 =
   let (arrK, arrA, arrB) = benchData @6 @Double 42
       hKrn, cKrn :: Concrete (TKS '[3, 3, 3, 3] Double)
       hKrn = conv2dPreserving_dKrn @3 @3 @3 @6 @6 @3 @3
-                             (sconcrete (unConcrete arrA)) (sconcrete (unConcrete arrB))
-      cKrn = cvjp @_ @_ @_ @Concrete (`conv2dPreservingS` sconcrete (unConcrete arrA))
+                                   (sconcrete (unConcrete arrA))
+                                   (sconcrete (unConcrete arrB))
+      cKrn = cvjp @_ @_ @_ @Concrete
+                  (`conv2dPreservingS` sconcrete (unConcrete arrA))
                   (sconcrete (unConcrete arrK)) (sconcrete (unConcrete arrB))
       hInp, cInp :: Concrete (TKS '[3, 3, 6, 6] Double)
       hInp = conv2dPreserving_dInp @3 @3 @3 @6 @6 @3 @3
-                             (sconcrete (unConcrete arrK)) (sconcrete (unConcrete arrB))
-      cInp = cvjp @_ @_ @_ @Concrete (conv2dPreservingS (sconcrete (unConcrete arrK)))
+                                   (sconcrete (unConcrete arrK))
+                                   (sconcrete (unConcrete arrB))
+      cInp = cvjp @_ @_ @_ @Concrete
+                  (conv2dPreservingS (sconcrete (unConcrete arrK)))
                   (sconcrete (unConcrete arrA)) (sconcrete (unConcrete arrB))
   in do assertEqualUpToEpsilon 1e-5 hKrn cKrn
         assertEqualUpToEpsilon 1e-5 hInp cInp
 
+-- At the small size, also check the handwritten terms with the incoming
+-- cotangent kept as a variable and bound in the environment, both raw and
+-- contracted — the exact terms the H-exec-raw and H-exec variants of
+-- bench/ConvVjpBench.hs interpret (the constant-cotangent form is covered
+-- by the vectorized legs above).
+conv2dPreservingVjpVarCotangent6 :: Assertion
+conv2dPreservingVjpVarCotangent6 =
+  let (arrK, arrA, arrB) = benchData @6 @Double 42
+      varNameB = mkAstVarName (FTKS (knownShS @'[3, 3, 6, 6])
+                                    (FTKScalar @Double))
+                              (intToAstVarId 100000099)
+      env = extendEnv varNameB arrB emptyEnv
+      hKrn, rawKrn, contractedKrn :: Concrete (TKS '[3, 3, 3, 3] Double)
+      hKrn = conv2dPreserving_dKrn @3 @3 @3 @6 @6 @3 @3
+                                   (sconcrete (unConcrete arrA))
+                                   (sconcrete (unConcrete arrB))
+      krnTermVar :: AstTensor AstMethodLet FullSpan (TKS '[3, 3, 3, 3] Double)
+      krnTermVar = conv2dPreserving_dKrn @3 @3 @3 @6 @6 @3 @3
+                                         (sconcrete (unConcrete arrA))
+                                         (AstVar varNameB)
+      rawKrn = interpretAstFull env krnTermVar
+      contractedKrn = interpretAstFull env (simplifyInlineContract krnTermVar)
+      hInp, rawInp, contractedInp :: Concrete (TKS '[3, 3, 6, 6] Double)
+      hInp = conv2dPreserving_dInp @3 @3 @3 @6 @6 @3 @3
+                                   (sconcrete (unConcrete arrK))
+                                   (sconcrete (unConcrete arrB))
+      inpTermVar :: AstTensor AstMethodLet FullSpan (TKS '[3, 3, 6, 6] Double)
+      inpTermVar = conv2dPreserving_dInp @3 @3 @3 @6 @6 @3 @3
+                                         (sconcrete (unConcrete arrK))
+                                         (AstVar varNameB)
+      rawInp = interpretAstFull env inpTermVar
+      contractedInp = interpretAstFull env (simplifyInlineContract inpTermVar)
+  in do assertEqualUpToEpsilon 1e-5 hKrn rawKrn
+        assertEqualUpToEpsilon 1e-5 hKrn contractedKrn
+        assertEqualUpToEpsilon 1e-5 hInp rawInp
+        assertEqualUpToEpsilon 1e-5 hInp contractedInp
+
 
 -- * The shrinking convolution variant
 
-conv2dShrinkingVjpKrnCorrect :: forall nAw. (KnownNat nAw, 1 <= nAw) => Assertion
+conv2dShrinkingVjpKrnCorrect
+  :: forall nAw. (KnownNat nAw, 1 <= nAw) => Assertion
 conv2dShrinkingVjpKrnCorrect =
   let (arrK, arrA, arrB) = benchDataShrinking @nAw @Double 42
-      handwritten, symbolic :: Concrete (TKS '[3, 3, 3, 3] Double)
+      handwritten, symbolic, vectorized :: Concrete (TKS '[3, 3, 3, 3] Double)
       handwritten = conv2dShrinking_dKrn @3 @3 @3 @nAw @nAw @2 @2
                                          (sconcrete (unConcrete arrA))
                                          (sconcrete (unConcrete arrB))
       symbolic = vjp (`conv2dShrinkingS` sconcrete (unConcrete arrA))
                      (sconcrete (unConcrete arrK)) (sconcrete (unConcrete arrB))
-  in assertEqualUpToEpsilon 1e-5 handwritten symbolic
+      vectorized = interpretAstFull emptyEnv
+                   $ conv2dShrinking_dKrn @3 @3 @3 @nAw @nAw @2 @2
+                                          (sconcrete (unConcrete arrA))
+                                          (sconcrete (unConcrete arrB))
+  in do assertEqualUpToEpsilon 1e-5 handwritten symbolic
+        assertEqualUpToEpsilon 1e-5 handwritten vectorized
 
 conv2dShrinkingVjpInpCorrect :: forall nAw. KnownNat nAw => Assertion
 conv2dShrinkingVjpInpCorrect =
   let (arrK, arrA, arrB) = benchDataShrinking @nAw @Double 42
-      handwritten, symbolic :: Concrete (TKS '[3, 3, nAw + 2, nAw + 2] Double)
+      handwritten, symbolic, vectorized
+        :: Concrete (TKS '[3, 3, nAw + 2, nAw + 2] Double)
       handwritten = conv2dShrinking_dInp @3 @3 @3 @nAw @nAw @2 @2
                                          (sconcrete (unConcrete arrK))
                                          (sconcrete (unConcrete arrB))
       symbolic = vjp (conv2dShrinkingS (sconcrete (unConcrete arrK)))
                      (sconcrete (unConcrete arrA)) (sconcrete (unConcrete arrB))
-  in assertEqualUpToEpsilon 1e-5 handwritten symbolic
+      vectorized = interpretAstFull emptyEnv
+                   $ conv2dShrinking_dInp @3 @3 @3 @nAw @nAw @2 @2
+                                          (sconcrete (unConcrete arrK))
+                                          (sconcrete (unConcrete arrB))
+  in do assertEqualUpToEpsilon 1e-5 handwritten symbolic
+        assertEqualUpToEpsilon 1e-5 handwritten vectorized
 
 conv2dShrinkingVjpConcrete6 :: Assertion
 conv2dShrinkingVjpConcrete6 =
   let (arrK, arrA, arrB) = benchDataShrinking @6 @Double 42
       hKrn, cKrn :: Concrete (TKS '[3, 3, 3, 3] Double)
       hKrn = conv2dShrinking_dKrn @3 @3 @3 @6 @6 @2 @2
-                                  (sconcrete (unConcrete arrA)) (sconcrete (unConcrete arrB))
-      cKrn = cvjp @_ @_ @_ @Concrete (`conv2dShrinkingS` sconcrete (unConcrete arrA))
+                                  (sconcrete (unConcrete arrA))
+                                  (sconcrete (unConcrete arrB))
+      cKrn = cvjp @_ @_ @_ @Concrete
+                  (`conv2dShrinkingS` sconcrete (unConcrete arrA))
                   (sconcrete (unConcrete arrK)) (sconcrete (unConcrete arrB))
       hInp, cInp :: Concrete (TKS '[3, 3, 8, 8] Double)
       hInp = conv2dShrinking_dInp @3 @3 @3 @6 @6 @2 @2
-                                  (sconcrete (unConcrete arrK)) (sconcrete (unConcrete arrB))
-      cInp = cvjp @_ @_ @_ @Concrete (conv2dShrinkingS (sconcrete (unConcrete arrK)))
+                                  (sconcrete (unConcrete arrK))
+                                  (sconcrete (unConcrete arrB))
+      cInp = cvjp @_ @_ @_ @Concrete
+                  (conv2dShrinkingS (sconcrete (unConcrete arrK)))
                   (sconcrete (unConcrete arrA)) (sconcrete (unConcrete arrB))
   in do assertEqualUpToEpsilon 1e-5 hKrn cKrn
         assertEqualUpToEpsilon 1e-5 hInp cInp
@@ -154,37 +254,52 @@ conv2dShrinkingVjpConcrete6 =
 conv2dPaddedVjpKrnCorrect :: forall nAw. (KnownNat nAw, 1 <= nAw) => Assertion
 conv2dPaddedVjpKrnCorrect =
   let (arrK, arrA, arrB) = benchDataPadded @nAw @Double 42
-      handwritten, symbolic :: Concrete (TKS '[3, 3, 3, 3] Double)
+      handwritten, symbolic, vectorized :: Concrete (TKS '[3, 3, 3, 3] Double)
       handwritten = conv2dPadded_dKrn @3 @3 @3 @nAw @nAw @2 @2
                                       (sconcrete (unConcrete arrA))
                                       (sconcrete (unConcrete arrB))
       symbolic = vjp (`conv2dPaddedS` sconcrete (unConcrete arrA))
                      (sconcrete (unConcrete arrK)) (sconcrete (unConcrete arrB))
-  in assertEqualUpToEpsilon 1e-5 handwritten symbolic
+      vectorized = interpretAstFull emptyEnv
+                   $ conv2dPadded_dKrn @3 @3 @3 @nAw @nAw @2 @2
+                                       (sconcrete (unConcrete arrA))
+                                       (sconcrete (unConcrete arrB))
+  in do assertEqualUpToEpsilon 1e-5 handwritten symbolic
+        assertEqualUpToEpsilon 1e-5 handwritten vectorized
 
 conv2dPaddedVjpInpCorrect :: forall nAw. KnownNat nAw => Assertion
 conv2dPaddedVjpInpCorrect =
   let (arrK, arrA, arrB) = benchDataPadded @nAw @Double 42
-      handwritten, symbolic :: Concrete (TKS '[3, 3, nAw, nAw] Double)
+      handwritten, symbolic, vectorized
+        :: Concrete (TKS '[3, 3, nAw, nAw] Double)
       handwritten = conv2dPadded_dInp @3 @3 @3 @nAw @nAw @2 @2
                                       (sconcrete (unConcrete arrK))
                                       (sconcrete (unConcrete arrB))
       symbolic = vjp (conv2dPaddedS (sconcrete (unConcrete arrK)))
                      (sconcrete (unConcrete arrA)) (sconcrete (unConcrete arrB))
-  in assertEqualUpToEpsilon 1e-5 handwritten symbolic
+      vectorized = interpretAstFull emptyEnv
+                   $ conv2dPadded_dInp @3 @3 @3 @nAw @nAw @2 @2
+                                       (sconcrete (unConcrete arrK))
+                                       (sconcrete (unConcrete arrB))
+  in do assertEqualUpToEpsilon 1e-5 handwritten symbolic
+        assertEqualUpToEpsilon 1e-5 handwritten vectorized
 
 conv2dPaddedVjpConcrete6 :: Assertion
 conv2dPaddedVjpConcrete6 =
   let (arrK, arrA, arrB) = benchDataPadded @6 @Double 42
       hKrn, cKrn :: Concrete (TKS '[3, 3, 3, 3] Double)
       hKrn = conv2dPadded_dKrn @3 @3 @3 @6 @6 @2 @2
-                               (sconcrete (unConcrete arrA)) (sconcrete (unConcrete arrB))
-      cKrn = cvjp @_ @_ @_ @Concrete (`conv2dPaddedS` sconcrete (unConcrete arrA))
+                               (sconcrete (unConcrete arrA))
+                               (sconcrete (unConcrete arrB))
+      cKrn = cvjp @_ @_ @_ @Concrete
+                  (`conv2dPaddedS` sconcrete (unConcrete arrA))
                   (sconcrete (unConcrete arrK)) (sconcrete (unConcrete arrB))
       hInp, cInp :: Concrete (TKS '[3, 3, 6, 6] Double)
       hInp = conv2dPadded_dInp @3 @3 @3 @6 @6 @2 @2
-                               (sconcrete (unConcrete arrK)) (sconcrete (unConcrete arrB))
-      cInp = cvjp @_ @_ @_ @Concrete (conv2dPaddedS (sconcrete (unConcrete arrK)))
+                               (sconcrete (unConcrete arrK))
+                               (sconcrete (unConcrete arrB))
+      cInp = cvjp @_ @_ @_ @Concrete
+                  (conv2dPaddedS (sconcrete (unConcrete arrK)))
                   (sconcrete (unConcrete arrA)) (sconcrete (unConcrete arrB))
   in do assertEqualUpToEpsilon 1e-5 hKrn cKrn
         assertEqualUpToEpsilon 1e-5 hInp cInp

--- a/test/simplified/TestConvCorrect.hs
+++ b/test/simplified/TestConvCorrect.hs
@@ -27,7 +27,7 @@ import EqEpsilon
 
 import TestConvQuickCheck
   ( benchData, benchDataShrinking, benchDataPadded
-  , conv2dSame_dKrn, conv2dSame_dInp
+  , conv2dPreserving_dKrn, conv2dPreserving_dInp
   , conv2dShrinking_dKrn, conv2dShrinking_dInp
   , conv2dPadded_dKrn, conv2dPadded_dInp )
 
@@ -38,14 +38,14 @@ testTrees =
   -- gradient must agree with the handwritten one — and, at the small size,
   -- with the concrete non-symbolic AD too — so the path those poor man's
   -- benchmarks time is verified correct at scale, not only timed.
-  -- Same convolution: input and output the same size.
-  [ testCase "conv2dSameVjp dKrn correct 6" (conv2dSameVjpKrnCorrect @6)
-  , testCase "conv2dSameVjp dKrn correct 24" (conv2dSameVjpKrnCorrect @24)
-  , testCase "conv2dSameVjp dKrn correct 96" (conv2dSameVjpKrnCorrect @96)
-  , testCase "conv2dSameVjp dInp correct 6" (conv2dSameVjpInpCorrect @6)
-  , testCase "conv2dSameVjp dInp correct 24" (conv2dSameVjpInpCorrect @24)
-  , testCase "conv2dSameVjp dInp correct 96" (conv2dSameVjpInpCorrect @96)
-  , testCase "conv2dSameVjp correct vs concrete 6" conv2dSameVjpConcrete6
+  -- Preserving convolution: input and output the same size.
+  [ testCase "conv2dPreservingVjp dKrn correct 6" (conv2dPreservingVjpKrnCorrect @6)
+  , testCase "conv2dPreservingVjp dKrn correct 24" (conv2dPreservingVjpKrnCorrect @24)
+  , testCase "conv2dPreservingVjp dKrn correct 96" (conv2dPreservingVjpKrnCorrect @96)
+  , testCase "conv2dPreservingVjp dInp correct 6" (conv2dPreservingVjpInpCorrect @6)
+  , testCase "conv2dPreservingVjp dInp correct 24" (conv2dPreservingVjpInpCorrect @24)
+  , testCase "conv2dPreservingVjp dInp correct 96" (conv2dPreservingVjpInpCorrect @96)
+  , testCase "conv2dPreservingVjp correct vs concrete 6" conv2dPreservingVjpConcrete6
   -- Shrinking convolution: input larger than output.
   , testCase "conv2dShrinkingVjp dKrn correct 6" (conv2dShrinkingVjpKrnCorrect @6)
   , testCase "conv2dShrinkingVjp dKrn correct 24" (conv2dShrinkingVjpKrnCorrect @24)
@@ -65,44 +65,44 @@ testTrees =
   ]
 
 
--- * The same convolution variant
+-- * The preserving convolution variant
 
-conv2dSameVjpKrnCorrect :: forall nAw. KnownNat nAw => Assertion
-conv2dSameVjpKrnCorrect =
+conv2dPreservingVjpKrnCorrect :: forall nAw. KnownNat nAw => Assertion
+conv2dPreservingVjpKrnCorrect =
   let (arrK, arrA, arrB) = benchData @nAw @Double 42
       handwritten, symbolic :: Concrete (TKS '[3, 3, 3, 3] Double)
-      handwritten = conv2dSame_dKrn @3 @3 @3 @nAw @nAw @3 @3
+      handwritten = conv2dPreserving_dKrn @3 @3 @3 @nAw @nAw @3 @3
                                     (sconcrete (unConcrete arrA))
                                     (sconcrete (unConcrete arrB))
-      symbolic = vjp (`conv2dSameS` sconcrete (unConcrete arrA))
+      symbolic = vjp (`conv2dPreservingS` sconcrete (unConcrete arrA))
                      (sconcrete (unConcrete arrK)) (sconcrete (unConcrete arrB))
   in assertEqualUpToEpsilon 1e-5 handwritten symbolic
 
-conv2dSameVjpInpCorrect :: forall nAw. KnownNat nAw => Assertion
-conv2dSameVjpInpCorrect =
+conv2dPreservingVjpInpCorrect :: forall nAw. KnownNat nAw => Assertion
+conv2dPreservingVjpInpCorrect =
   let (arrK, arrA, arrB) = benchData @nAw @Double 42
       handwritten, symbolic :: Concrete (TKS '[3, 3, nAw, nAw] Double)
-      handwritten = conv2dSame_dInp @3 @3 @3 @nAw @nAw @3 @3
+      handwritten = conv2dPreserving_dInp @3 @3 @3 @nAw @nAw @3 @3
                                     (sconcrete (unConcrete arrK))
                                     (sconcrete (unConcrete arrB))
-      symbolic = vjp (conv2dSameS (sconcrete (unConcrete arrK)))
+      symbolic = vjp (conv2dPreservingS (sconcrete (unConcrete arrK)))
                      (sconcrete (unConcrete arrA)) (sconcrete (unConcrete arrB))
   in assertEqualUpToEpsilon 1e-5 handwritten symbolic
 
 -- At the small size, also check the symbolic gradient against the concrete
 -- (non-symbolic) AD, which is too slow to run at the larger sizes.
-conv2dSameVjpConcrete6 :: Assertion
-conv2dSameVjpConcrete6 =
+conv2dPreservingVjpConcrete6 :: Assertion
+conv2dPreservingVjpConcrete6 =
   let (arrK, arrA, arrB) = benchData @6 @Double 42
       hKrn, cKrn :: Concrete (TKS '[3, 3, 3, 3] Double)
-      hKrn = conv2dSame_dKrn @3 @3 @3 @6 @6 @3 @3
+      hKrn = conv2dPreserving_dKrn @3 @3 @3 @6 @6 @3 @3
                              (sconcrete (unConcrete arrA)) (sconcrete (unConcrete arrB))
-      cKrn = cvjp @_ @_ @_ @Concrete (`conv2dSameS` sconcrete (unConcrete arrA))
+      cKrn = cvjp @_ @_ @_ @Concrete (`conv2dPreservingS` sconcrete (unConcrete arrA))
                   (sconcrete (unConcrete arrK)) (sconcrete (unConcrete arrB))
       hInp, cInp :: Concrete (TKS '[3, 3, 6, 6] Double)
-      hInp = conv2dSame_dInp @3 @3 @3 @6 @6 @3 @3
+      hInp = conv2dPreserving_dInp @3 @3 @3 @6 @6 @3 @3
                              (sconcrete (unConcrete arrK)) (sconcrete (unConcrete arrB))
-      cInp = cvjp @_ @_ @_ @Concrete (conv2dSameS (sconcrete (unConcrete arrK)))
+      cInp = cvjp @_ @_ @_ @Concrete (conv2dPreservingS (sconcrete (unConcrete arrK)))
                   (sconcrete (unConcrete arrA)) (sconcrete (unConcrete arrB))
   in do assertEqualUpToEpsilon 1e-5 hKrn cKrn
         assertEqualUpToEpsilon 1e-5 hInp cInp

--- a/test/simplified/TestConvQuickCheck.hs
+++ b/test/simplified/TestConvQuickCheck.hs
@@ -10,7 +10,7 @@ module TestConvQuickCheck
   ( testTrees
     -- * Shared with "TestConvCorrect"
   , benchData, benchDataShrinking, benchDataPadded
-  , conv2dSame_dKrn, conv2dSame_dInp
+  , conv2dPreserving_dKrn, conv2dPreserving_dInp
   , conv2dShrinking_dKrn, conv2dShrinking_dInp
   , conv2dPadded_dKrn, conv2dPadded_dInp
   ) where
@@ -45,12 +45,12 @@ import MnistFcnnRanked2 qualified
 testTrees :: [TestTree]
 testTrees =
   [ tensorADOnceMnistTests2
-  , testCase "conv2dSameVjp dInp" test_conv2dSameVjp_dInp
-  , testCase "conv2dSameVjp dKrn" test_conv2dSameVjp_dKrn
-  , testProperty "conv2dSameVjp Quickcheck Double"
-                 (quickcheck_conv2dSameVjp @Double)
-  , testProperty "conv2dSameVjp Quickcheck Float"
-                 (quickcheck_conv2dSameVjp @Float)
+  , testCase "conv2dPreservingVjp dInp" test_conv2dPreservingVjp_dInp
+  , testCase "conv2dPreservingVjp dKrn" test_conv2dPreservingVjp_dKrn
+  , testProperty "conv2dPreservingVjp Quickcheck Double"
+                 (quickcheck_conv2dPreservingVjp @Double)
+  , testProperty "conv2dPreservingVjp Quickcheck Float"
+                 (quickcheck_conv2dPreservingVjp @Float)
   , testCase "conv2dShrinkingVjp dInp" test_conv2dShrinkingVjp_dInp
   , testCase "conv2dShrinkingVjp dKrn" test_conv2dShrinkingVjp_dKrn
   , testProperty "conv2dShrinkingVjp Quickcheck Double"
@@ -63,10 +63,10 @@ testTrees =
                  (quickcheck_conv2dPaddedVjp @Double)
   , testProperty "conv2dPaddedVjp Quickcheck Float"
                  (quickcheck_conv2dPaddedVjp @Float)
-  , testProperty "conv2dSameJvp Quickcheck Double"
-                 (quickcheck_conv2dSameJvp @Double)
-  , testProperty "conv2dSameJvp Quickcheck Float"
-                 (quickcheck_conv2dSameJvp @Float)
+  , testProperty "conv2dPreservingJvp Quickcheck Double"
+                 (quickcheck_conv2dPreservingJvp @Double)
+  , testProperty "conv2dPreservingJvp Quickcheck Float"
+                 (quickcheck_conv2dPreservingJvp @Float)
   , testProperty "conv2dShrinkingJvp Quickcheck Double"
                  (quickcheck_conv2dShrinkingJvp @Double)
   , testProperty "conv2dShrinkingJvp Quickcheck Float"
@@ -75,53 +75,53 @@ testTrees =
                  (quickcheck_conv2dPaddedJvp @Double)
   , testProperty "conv2dPaddedJvp Quickcheck Float"
                  (quickcheck_conv2dPaddedJvp @Float)
-  , testProperty "conv2dSameVjp Bench dKrn Handwritten warmup"
-                 (quickcheck_conv2dSameVjpKrnHandwritten @Double)
-  , testProperty "conv2dSameVjp Bench dKrn Handwritten"
-                 (quickcheck_conv2dSameVjpKrnHandwritten @Double)
-  , testProperty "conv2dSameVjp Bench dKrn HandwrittenVectorized"
-                 (quickcheck_conv2dSameVjpKrnHandwrittenVectorized @Double)
-  , testProperty "conv2dSameVjp Bench dKrn Symbolic"
-                 (quickcheck_conv2dSameVjpKrnSymbolic @Double)
-  , testProperty "conv2dSameVjp Bench dKrn Concrete"
-                 (quickcheck_conv2dSameVjpKrnConcrete @Double)
-  , testProperty "conv2dSameVjp Bench dInp Handwritten"
-                 (quickcheck_conv2dSameVjpInpHandwritten @Double)
-  , testProperty "conv2dSameVjp Bench dInp HandwrittenVectorized"
-                 (quickcheck_conv2dSameVjpInpHandwrittenVectorized @Double)
-  , testProperty "conv2dSameVjp Bench dInp Symbolic"
-                 (quickcheck_conv2dSameVjpInpSymbolic @Double)
-  , testProperty "conv2dSameVjp Bench dInp Concrete"
-                 (quickcheck_conv2dSameVjpInpConcrete @Double)
+  , testProperty "conv2dPreservingVjp Bench dKrn Handwritten warmup"
+                 (quickcheck_conv2dPreservingVjpKrnHandwritten @Double)
+  , testProperty "conv2dPreservingVjp Bench dKrn Handwritten"
+                 (quickcheck_conv2dPreservingVjpKrnHandwritten @Double)
+  , testProperty "conv2dPreservingVjp Bench dKrn HandwrittenVectorized"
+                 (quickcheck_conv2dPreservingVjpKrnHandwrittenVectorized @Double)
+  , testProperty "conv2dPreservingVjp Bench dKrn Symbolic"
+                 (quickcheck_conv2dPreservingVjpKrnSymbolic @Double)
+  , testProperty "conv2dPreservingVjp Bench dKrn Concrete"
+                 (quickcheck_conv2dPreservingVjpKrnConcrete @Double)
+  , testProperty "conv2dPreservingVjp Bench dInp Handwritten"
+                 (quickcheck_conv2dPreservingVjpInpHandwritten @Double)
+  , testProperty "conv2dPreservingVjp Bench dInp HandwrittenVectorized"
+                 (quickcheck_conv2dPreservingVjpInpHandwrittenVectorized @Double)
+  , testProperty "conv2dPreservingVjp Bench dInp Symbolic"
+                 (quickcheck_conv2dPreservingVjpInpSymbolic @Double)
+  , testProperty "conv2dPreservingVjp Bench dInp Concrete"
+                 (quickcheck_conv2dPreservingVjpInpConcrete @Double)
   -- Size-scaled poor man's benchmarks (see the definitions below), for the
   -- same, shrinking and padded convolutions, and for both the kernel and the
   -- input gradient. The matching gradient-correctness checks live in
   -- "TestConvCorrect", kept separate so the testsuite's non-QuickCheck, more
   -- deterministically timed tests can be compared as a group.
-  -- Same convolution: input and output the same size.
-  , testProperty "conv2dSameVjp Bench dKrn 6 SymbolicPerCall"
+  -- Preserving convolution: input and output the same size.
+  , testProperty "conv2dPreservingVjp Bench dKrn 6 SymbolicPerCall"
                  (sizedSymbolicPerCall @6)
-  , testProperty "conv2dSameVjp Bench dKrn 6 SymbolicAmortized"
+  , testProperty "conv2dPreservingVjp Bench dKrn 6 SymbolicAmortized"
                  (sizedSymbolicAmortized @6)
-  , testProperty "conv2dSameVjp Bench dKrn 6 HandwrittenVectorized"
+  , testProperty "conv2dPreservingVjp Bench dKrn 6 HandwrittenVectorized"
                  (sizedHandwrittenVectorized @6)
-  , testProperty "conv2dSameVjp Bench dKrn 24 SymbolicPerCall"
+  , testProperty "conv2dPreservingVjp Bench dKrn 24 SymbolicPerCall"
                  (sizedSymbolicPerCall @24)
-  , testProperty "conv2dSameVjp Bench dKrn 24 SymbolicAmortized"
+  , testProperty "conv2dPreservingVjp Bench dKrn 24 SymbolicAmortized"
                  (sizedSymbolicAmortized @24)
-  , testProperty "conv2dSameVjp Bench dKrn 24 HandwrittenVectorized"
+  , testProperty "conv2dPreservingVjp Bench dKrn 24 HandwrittenVectorized"
                  (sizedHandwrittenVectorized @24)
-  , testProperty "conv2dSameVjp Bench dInp 6 SymbolicPerCall"
+  , testProperty "conv2dPreservingVjp Bench dInp 6 SymbolicPerCall"
                  (sizedSymbolicPerCallInp @6)
-  , testProperty "conv2dSameVjp Bench dInp 6 SymbolicAmortized"
+  , testProperty "conv2dPreservingVjp Bench dInp 6 SymbolicAmortized"
                  (sizedSymbolicAmortizedInp @6)
-  , testProperty "conv2dSameVjp Bench dInp 6 HandwrittenVectorized"
+  , testProperty "conv2dPreservingVjp Bench dInp 6 HandwrittenVectorized"
                  (sizedHandwrittenVectorizedInp @6)
-  , testProperty "conv2dSameVjp Bench dInp 24 SymbolicPerCall"
+  , testProperty "conv2dPreservingVjp Bench dInp 24 SymbolicPerCall"
                  (sizedSymbolicPerCallInp @24)
-  , testProperty "conv2dSameVjp Bench dInp 24 SymbolicAmortized"
+  , testProperty "conv2dPreservingVjp Bench dInp 24 SymbolicAmortized"
                  (sizedSymbolicAmortizedInp @24)
-  , testProperty "conv2dSameVjp Bench dInp 24 HandwrittenVectorized"
+  , testProperty "conv2dPreservingVjp Bench dInp 24 HandwrittenVectorized"
                  (sizedHandwrittenVectorizedInp @24)
   -- Shrinking convolution: input larger than output.
   , testProperty "conv2dShrinkingVjp Bench dKrn 6 SymbolicPerCall"
@@ -282,8 +282,8 @@ flip42 arr =
 
 -- | Hand-written reverse derivative of full convolution with respect
 -- to the input image.
--- Example code that horde-ad generates for the same is in testSameCNNOPP0bW.
-conv2dSame_dInp
+-- Example code that horde-ad generates for the same is in testPreservingCNNOPP0bW.
+conv2dPreserving_dInp
   :: forall nImgs nCinp nCout nAh nAw nKh nKw shK shA shB shB1
             target r.
      ( KnownNat nImgs, KnownNat nCinp, KnownNat nCout
@@ -296,7 +296,7 @@ conv2dSame_dInp
   => target (TKS shK r)
   -> target (TKS shB r)
   -> target (TKS shA r)
-conv2dSame_dInp arrK arrB =
+conv2dPreserving_dInp arrK arrB =
   let arrKFlipped = flip42 arrK
       nKh = valueOf @nKh
       nKw = valueOf @nKw
@@ -307,16 +307,16 @@ conv2dSame_dInp arrK arrB =
           arrKt = slicezS (stranspose @'[1, 0] arrKFlipped)
                           [iCinp, 0 , 0, 0]
       in sfromK $ sdot0 arrBt arrKt
-    _ -> error "conv2dSame_dInp: impossible pattern needlessly required"
+    _ -> error "conv2dPreserving_dInp: impossible pattern needlessly required"
 -- Note that
--- > ... in conv2dSameS (stranspose @'[1, 0] arrKFlipped) arrB
+-- > ... in conv2dPreservingS (stranspose @'[1, 0] arrKFlipped) arrB
 -- type-checks above, but test fails due to the lack of @- nKh + 1@.
 
 -- | Hand-written reverse derivative of full convolution with respect
 -- to the kernels.
--- This code vectorized is pretty-printed in test testSameCNNOPPKrnHandwritten.
--- Example code that horde-ad generates for the same is in testSameCNNOPP0cW.
-conv2dSame_dKrn
+-- This code vectorized is pretty-printed in test testPreservingCNNOPPKrnHandwritten.
+-- Example code that horde-ad generates for the same is in testPreservingCNNOPP0cW.
+conv2dPreserving_dKrn
   :: forall nImgs nCinp nCout nAh nAw nKh nKw shK shA shB shB1
             target r.
      ( KnownNat nImgs, KnownNat nCinp, KnownNat nCout
@@ -329,7 +329,7 @@ conv2dSame_dKrn
   => target (TKS shA r)
   -> target (TKS shB r)
   -> target (TKS shK r)
-conv2dSame_dKrn arrA arrB =
+conv2dPreserving_dKrn arrA arrB =
   sbuild @shK $ \case
     [iCout, iCinp, iKh, iKw] ->
       let arrBt = slicezS @shB1 arrB
@@ -337,10 +337,10 @@ conv2dSame_dKrn arrA arrB =
           arrAt = slicezS arrA
                           [0, iCinp, iKh, iKw]
       in sfromK $ sdot0 arrBt arrAt
-    _ -> error "conv2dSame_dKrn: impossible pattern needlessly required"
+    _ -> error "conv2dPreserving_dKrn: impossible pattern needlessly required"
 
-test_conv2dSameVjp_dInp :: Assertion
-test_conv2dSameVjp_dInp =
+test_conv2dPreservingVjp_dInp :: Assertion
+test_conv2dPreservingVjp_dInp =
   let -- Input of shape: batch x chas x height x width
       arrA :: Nested.Shaped '[5, 2, 4, 8] Double
       arrA = Nested.sreplicatePrim knownShS 1.1
@@ -352,14 +352,14 @@ test_conv2dSameVjp_dInp =
       arrB = Nested.sreplicatePrim knownShS (-3.3)
       -- Compare the AD version against the manual derivative.
       dInp :: Concrete (TKS '[5, 2, 4, 8] Double)
-      dInp = conv2dSame_dInp (sconcrete arrK) (sconcrete arrB)
+      dInp = conv2dPreserving_dInp (sconcrete arrK) (sconcrete arrB)
       vjpInp = cvjp @_ @_ @_ @Concrete
-                    (conv2dSameS (sconcrete arrK))
+                    (conv2dPreservingS (sconcrete arrK))
                     (sconcrete arrA) (sconcrete arrB)
   in assertEqualUpToEpsilon 1e-7 dInp vjpInp
 
-test_conv2dSameVjp_dKrn :: Assertion
-test_conv2dSameVjp_dKrn =
+test_conv2dPreservingVjp_dKrn :: Assertion
+test_conv2dPreservingVjp_dKrn =
   let -- Input of shape: batch x chas x height x width
       arrA :: Nested.Shaped '[5, 2, 4, 8] Double
       arrA = Nested.sreplicatePrim knownShS 1.1
@@ -371,13 +371,13 @@ test_conv2dSameVjp_dKrn =
       arrB = Nested.sreplicatePrim knownShS (-3.3)
       -- Compare the AD version against the manual derivative.
       dKrn :: Concrete (TKS '[7, 2, 1, 3] Double)
-      dKrn = conv2dSame_dKrn (sconcrete arrA) (sconcrete arrB)
+      dKrn = conv2dPreserving_dKrn (sconcrete arrA) (sconcrete arrB)
       vjpKrn = cvjp @_ @_ @_ @Concrete
-                    (`conv2dSameS` sconcrete arrA)
+                    (`conv2dPreservingS` sconcrete arrA)
                     (sconcrete arrK) (sconcrete arrB)
   in assertEqualUpToEpsilon 1e-7 dKrn vjpKrn
 
-static_conv2dSameVjp
+static_conv2dPreservingVjp
   :: forall nImgs nCinp nCout nAh nAw nKh nKw shK shA shB r.
      ( NumScalar r, Differentiable r
      , shK ~ '[nCout, nCinp, nKh, nKw]
@@ -393,38 +393,38 @@ static_conv2dSameVjp
        -- ^ Output gradient of shape:
        --     batch x chas x output_height x output_width
   -> Bool
-static_conv2dSameVjp SNat SNat SNat SNat SNat SNat SNat arrK arrA arrB =
+static_conv2dPreservingVjp SNat SNat SNat SNat SNat SNat SNat arrK arrA arrB =
   let -- Compare the AD version against the manual derivative.
       -- Note that manual versions don't take one of the arguments (the point
       -- at which the gradient is taken), because maths (something about
       -- convolution being linear and so gradient the same everywhere).
       -- First, the gradient wrt the input image taken at point @arrA@.
       dInp :: Concrete (TKS shA r)
-      dInp = conv2dSame_dInp
+      dInp = conv2dPreserving_dInp
                (sconcrete arrK) (sconcrete arrB)  -- handwritten
-      vjpInp = vjp (conv2dSameS (sconcrete arrK))
+      vjpInp = vjp (conv2dPreservingS (sconcrete arrK))
                    (sconcrete arrA) (sconcrete arrB)  -- symbolic
       cvjpInp = cvjp @_ @_ @_ @Concrete
-                     (conv2dSameS (sconcrete arrK))
+                     (conv2dPreservingS (sconcrete arrK))
                      (sconcrete arrA) (sconcrete arrB)  -- concrete
       -- Second, the gradient wrt the kernels taken at point @arrK@.
       dKrn :: Concrete (TKS shK r)
-      dKrn = conv2dSame_dKrn
+      dKrn = conv2dPreserving_dKrn
                (sconcrete arrA) (sconcrete arrB)  -- handwritten
-      vjpKrn = vjp (`conv2dSameS` sconcrete arrA)
+      vjpKrn = vjp (`conv2dPreservingS` sconcrete arrA)
                    (sconcrete arrK) (sconcrete arrB)  -- symbolic
       cvjpKrn = cvjp @_ @_ @_ @Concrete
-                     (`conv2dSameS` sconcrete arrA)
+                     (`conv2dPreservingS` sconcrete arrA)
                      (sconcrete arrK) (sconcrete arrB)  -- concrete
   in allClose vjpInp dInp 1e-5  -- 1e-7 is too much for Float
      && allClose cvjpInp dInp 1e-5
      && allClose vjpKrn dKrn 1e-5
      && allClose cvjpKrn dKrn 1e-5
 
-quickcheck_conv2dSameVjp
+quickcheck_conv2dPreservingVjp
   :: forall r. (NumScalar r, Differentiable r)
   => Property
-quickcheck_conv2dSameVjp =
+quickcheck_conv2dPreservingVjp =
   forAll (choose (0, 5)) $ \nImgs' ->
   forAll (choose (0, 5)) $ \nCinp' ->
   forAll (choose (0, 5)) $ \nCout' ->
@@ -448,7 +448,7 @@ quickcheck_conv2dSameVjp =
             (arrA, seed3) = randomValue 0.5 seed2
             arrB :: Concrete (TKS '[nImgs, nCout, nAh, nAw] r)
             (arrB, _) = randomValue 0.5 seed3
-        in static_conv2dSameVjp
+        in static_conv2dPreservingVjp
              nImgs nCinp nCout nAh nAw nKh nKw
              (unConcrete arrK) (unConcrete arrA) (unConcrete arrB)
 
@@ -793,7 +793,7 @@ quickcheck_conv2dPaddedVjp =
     in b
 
 -- Forward derivative.
-static_conv2dSameJvp
+static_conv2dPreservingJvp
   :: forall nImgs nCinp nCout nAh nAw nKh nKw shK shA shB r.
      ( NumScalar r, Differentiable r
      , shK ~ '[nCout, nCinp, nKh, nKw]
@@ -804,31 +804,31 @@ static_conv2dSameJvp
   -> Nested.Shaped shK r -> Nested.Shaped shK r
   -> Nested.Shaped shA r -> Nested.Shaped shA r
   -> Bool
-static_conv2dSameJvp SNat SNat SNat SNat SNat SNat SNat
+static_conv2dPreservingJvp SNat SNat SNat SNat SNat SNat SNat
                      arrK arrK2 arrA arrA2 =
   let dInp :: Concrete (TKS shB r)
-      dInp = conv2dSameS (sconcrete arrK) (sconcrete arrA2)
-      jvpInp = jvp (conv2dSameS (sconcrete arrK))
+      dInp = conv2dPreservingS (sconcrete arrK) (sconcrete arrA2)
+      jvpInp = jvp (conv2dPreservingS (sconcrete arrK))
                    (sconcrete arrA) (sconcrete arrA2)
       cjvpInp = cjvp @_ @_ @_ @Concrete
-                     (conv2dSameS (sconcrete arrK))
+                     (conv2dPreservingS (sconcrete arrK))
                      (sconcrete arrA) (sconcrete arrA2)
       dKrn :: Concrete (TKS shB r)
-      dKrn = conv2dSameS (sconcrete arrK2) (sconcrete arrA)
-      jvpKrn = jvp (`conv2dSameS` sconcrete arrA)
+      dKrn = conv2dPreservingS (sconcrete arrK2) (sconcrete arrA)
+      jvpKrn = jvp (`conv2dPreservingS` sconcrete arrA)
                    (sconcrete arrK) (sconcrete arrK2)
       cjvpKrn = cjvp @_ @_ @_ @Concrete
-                     (`conv2dSameS` sconcrete arrA)
+                     (`conv2dPreservingS` sconcrete arrA)
                      (sconcrete arrK) (sconcrete arrK2)
   in allClose jvpInp dInp 1e-5  -- 1e-7 is too much for Float
      && allClose cjvpInp dInp 1e-5
      && allClose jvpKrn dKrn 1e-5
      && allClose cjvpKrn dKrn 1e-5
 
-quickcheck_conv2dSameJvp
+quickcheck_conv2dPreservingJvp
   :: forall r. (NumScalar r, Differentiable r)
   => Property
-quickcheck_conv2dSameJvp =
+quickcheck_conv2dPreservingJvp =
   forAll (choose (0, 5)) $ \nImgs' ->
   forAll (choose (0, 5)) $ \nCinp' ->
   forAll (choose (0, 5)) $ \nCout' ->
@@ -852,7 +852,7 @@ quickcheck_conv2dSameJvp =
             arrA, arrA2 :: Concrete (TKS '[nImgs, nCinp, nAh, nAw] r)
             (arrA, seed4) = randomValue 0.5 seed3
             (arrA2, _) = randomValue 0.5 seed4
-        in static_conv2dSameJvp
+        in static_conv2dPreservingJvp
              nImgs nCinp nCout nAh nAw nKh nKw
              (unConcrete arrK) (unConcrete arrK2)
              (unConcrete arrA) (unConcrete arrA2)
@@ -992,7 +992,7 @@ quickcheck_conv2dPaddedJvp =
 
 -- * Tests as poor man's benchmarks of handwritten vs generated gradients
 
-static_conv2dSameVjpKrnHandwritten
+static_conv2dPreservingVjpKrnHandwritten
   :: forall nImgs nCinp nCout nAh nAw nKh nKw shK shA shB r.
      ( NumScalar r, Differentiable r
      , shK ~ '[nCout, nCinp, nKh, nKw]
@@ -1004,16 +1004,16 @@ static_conv2dSameVjpKrnHandwritten
   -> Nested.Shaped shA r
   -> Nested.Shaped shB r
   -> Bool
-static_conv2dSameVjpKrnHandwritten SNat SNat SNat SNat SNat SNat SNat
+static_conv2dPreservingVjpKrnHandwritten SNat SNat SNat SNat SNat SNat SNat
                                    !_arrK arrA arrB =
   let dKrn :: Concrete (TKS shK r)
-      dKrn = conv2dSame_dKrn (sconcrete arrA) (sconcrete arrB)
+      dKrn = conv2dPreserving_dKrn (sconcrete arrA) (sconcrete arrB)
   in allClose dKrn dKrn 1e-5
 
-quickcheck_conv2dSameVjpKrnHandwritten
+quickcheck_conv2dPreservingVjpKrnHandwritten
   :: forall r. (NumScalar r, Differentiable r)
   => Property
-quickcheck_conv2dSameVjpKrnHandwritten =
+quickcheck_conv2dPreservingVjpKrnHandwritten =
   forAll (choose (3, 3)) $ \nImgs' ->
   forAll (choose (3, 3)) $ \nCinp' ->
   forAll (choose (3, 3)) $ \nCout' ->
@@ -1035,11 +1035,11 @@ quickcheck_conv2dSameVjpKrnHandwritten =
             (arrA, seed3) = randomValue 0.5 seed2
             arrB :: Concrete (TKS '[nImgs, nCout, nAh, nAw] r)
             (arrB, _) = randomValue 0.5 seed3
-        in static_conv2dSameVjpKrnHandwritten
+        in static_conv2dPreservingVjpKrnHandwritten
              nImgs nCinp nCout nAh nAw nKh nKw
              (unConcrete arrK) (unConcrete arrA) (unConcrete arrB)
 
-static_conv2dSameVjpKrnHandwrittenVectorized
+static_conv2dPreservingVjpKrnHandwrittenVectorized
   :: forall nImgs nCinp nCout nAh nAw nKh nKw shK shA shB r.
      ( NumScalar r, Differentiable r
      , shK ~ '[nCout, nCinp, nKh, nKw]
@@ -1051,17 +1051,17 @@ static_conv2dSameVjpKrnHandwrittenVectorized
   -> Nested.Shaped shA r
   -> Nested.Shaped shB r
   -> Bool
-static_conv2dSameVjpKrnHandwrittenVectorized SNat SNat SNat SNat SNat SNat SNat
+static_conv2dPreservingVjpKrnHandwrittenVectorized SNat SNat SNat SNat SNat SNat SNat
                                              !_arrK arrA arrB =
   let dKrn :: Concrete (TKS shK r)
       dKrn = interpretAstFull emptyEnv
-             $ conv2dSame_dKrn (sconcrete arrA) (sconcrete arrB)
+             $ conv2dPreserving_dKrn (sconcrete arrA) (sconcrete arrB)
   in allClose dKrn dKrn 1e-5
 
-quickcheck_conv2dSameVjpKrnHandwrittenVectorized
+quickcheck_conv2dPreservingVjpKrnHandwrittenVectorized
   :: forall r. (NumScalar r, Differentiable r)
   => Property
-quickcheck_conv2dSameVjpKrnHandwrittenVectorized =
+quickcheck_conv2dPreservingVjpKrnHandwrittenVectorized =
   forAll (choose (3, 3)) $ \nImgs' ->
   forAll (choose (3, 3)) $ \nCinp' ->
   forAll (choose (3, 3)) $ \nCout' ->
@@ -1083,11 +1083,11 @@ quickcheck_conv2dSameVjpKrnHandwrittenVectorized =
             (arrA, seed3) = randomValue 0.5 seed2
             arrB :: Concrete (TKS '[nImgs, nCout, nAh, nAw] r)
             (arrB, _) = randomValue 0.5 seed3
-        in static_conv2dSameVjpKrnHandwrittenVectorized
+        in static_conv2dPreservingVjpKrnHandwrittenVectorized
              nImgs nCinp nCout nAh nAw nKh nKw
              (unConcrete arrK) (unConcrete arrA) (unConcrete arrB)
 
-static_conv2dSameVjpKrnSymbolic
+static_conv2dPreservingVjpKrnSymbolic
   :: forall nImgs nCinp nCout nAh nAw nKh nKw shK shA shB r.
      ( NumScalar r, Differentiable r
      , shK ~ '[nCout, nCinp, nKh, nKw]
@@ -1099,17 +1099,17 @@ static_conv2dSameVjpKrnSymbolic
   -> Nested.Shaped shA r
   -> Nested.Shaped shB r
   -> Bool
-static_conv2dSameVjpKrnSymbolic SNat SNat SNat SNat SNat SNat SNat
+static_conv2dPreservingVjpKrnSymbolic SNat SNat SNat SNat SNat SNat SNat
                                 arrK arrA arrB =
   let vjpKrn :: Concrete (TKS shK r)
-      vjpKrn = vjp (`conv2dSameS` sconcrete arrA)
+      vjpKrn = vjp (`conv2dPreservingS` sconcrete arrA)
                    (sconcrete arrK) (sconcrete arrB)
   in allClose vjpKrn vjpKrn 1e-5
 
-quickcheck_conv2dSameVjpKrnSymbolic
+quickcheck_conv2dPreservingVjpKrnSymbolic
   :: forall r. (NumScalar r, Differentiable r)
   => Property
-quickcheck_conv2dSameVjpKrnSymbolic =
+quickcheck_conv2dPreservingVjpKrnSymbolic =
   forAll (choose (3, 3)) $ \nImgs' ->
   forAll (choose (3, 3)) $ \nCinp' ->
   forAll (choose (3, 3)) $ \nCout' ->
@@ -1131,11 +1131,11 @@ quickcheck_conv2dSameVjpKrnSymbolic =
             (arrA, seed3) = randomValue 0.5 seed2
             arrB :: Concrete (TKS '[nImgs, nCout, nAh, nAw] r)
             (arrB, _) = randomValue 0.5 seed3
-        in static_conv2dSameVjpKrnSymbolic
+        in static_conv2dPreservingVjpKrnSymbolic
              nImgs nCinp nCout nAh nAw nKh nKw
              (unConcrete arrK) (unConcrete arrA) (unConcrete arrB)
 
-static_conv2dSameVjpKrnConcrete
+static_conv2dPreservingVjpKrnConcrete
   :: forall nImgs nCinp nCout nAh nAw nKh nKw shK shA shB r.
      ( NumScalar r, Differentiable r
      , shK ~ '[nCout, nCinp, nKh, nKw]
@@ -1147,18 +1147,18 @@ static_conv2dSameVjpKrnConcrete
   -> Nested.Shaped shA r
   -> Nested.Shaped shB r
   -> Bool
-static_conv2dSameVjpKrnConcrete SNat SNat SNat SNat SNat SNat SNat
+static_conv2dPreservingVjpKrnConcrete SNat SNat SNat SNat SNat SNat SNat
                                 arrK arrA arrB =
   let cvjpKrn :: Concrete (TKS shK r)
       cvjpKrn = cvjp @_ @_ @_ @Concrete
-                     (`conv2dSameS` sconcrete arrA)
+                     (`conv2dPreservingS` sconcrete arrA)
                      (sconcrete arrK) (sconcrete arrB)
   in allClose cvjpKrn cvjpKrn 1e-5
 
-quickcheck_conv2dSameVjpKrnConcrete
+quickcheck_conv2dPreservingVjpKrnConcrete
   :: forall r. (NumScalar r, Differentiable r)
   => Property
-quickcheck_conv2dSameVjpKrnConcrete =
+quickcheck_conv2dPreservingVjpKrnConcrete =
   forAll (choose (3, 3)) $ \nImgs' ->
   forAll (choose (3, 3)) $ \nCinp' ->
   forAll (choose (3, 3)) $ \nCout' ->
@@ -1180,11 +1180,11 @@ quickcheck_conv2dSameVjpKrnConcrete =
             (arrA, seed3) = randomValue 0.5 seed2
             arrB :: Concrete (TKS '[nImgs, nCout, nAh, nAw] r)
             (arrB, _) = randomValue 0.5 seed3
-        in static_conv2dSameVjpKrnConcrete
+        in static_conv2dPreservingVjpKrnConcrete
              nImgs nCinp nCout nAh nAw nKh nKw
              (unConcrete arrK) (unConcrete arrA) (unConcrete arrB)
 
-static_conv2dSameVjpInpHandwritten
+static_conv2dPreservingVjpInpHandwritten
   :: forall nImgs nCinp nCout nAh nAw nKh nKw shK shA shB r.
      ( NumScalar r, Differentiable r
      , shK ~ '[nCout, nCinp, nKh, nKw]
@@ -1196,16 +1196,16 @@ static_conv2dSameVjpInpHandwritten
   -> Nested.Shaped shA r
   -> Nested.Shaped shB r
   -> Bool
-static_conv2dSameVjpInpHandwritten SNat SNat SNat SNat SNat SNat SNat
+static_conv2dPreservingVjpInpHandwritten SNat SNat SNat SNat SNat SNat SNat
                                    arrK !_arrA arrB =
   let dInp :: Concrete (TKS shA r)
-      dInp = conv2dSame_dInp (sconcrete arrK) (sconcrete arrB)
+      dInp = conv2dPreserving_dInp (sconcrete arrK) (sconcrete arrB)
   in allClose dInp dInp 1e-5
 
-quickcheck_conv2dSameVjpInpHandwritten
+quickcheck_conv2dPreservingVjpInpHandwritten
   :: forall r. (NumScalar r, Differentiable r)
   => Property
-quickcheck_conv2dSameVjpInpHandwritten =
+quickcheck_conv2dPreservingVjpInpHandwritten =
   forAll (choose (3, 3)) $ \nImgs' ->
   forAll (choose (3, 3)) $ \nCinp' ->
   forAll (choose (3, 3)) $ \nCout' ->
@@ -1227,11 +1227,11 @@ quickcheck_conv2dSameVjpInpHandwritten =
             (arrA, seed3) = randomValue 0.5 seed2
             arrB :: Concrete (TKS '[nImgs, nCout, nAh, nAw] r)
             (arrB, _) = randomValue 0.5 seed3
-        in static_conv2dSameVjpInpHandwritten
+        in static_conv2dPreservingVjpInpHandwritten
              nImgs nCinp nCout nAh nAw nKh nKw
              (unConcrete arrK) (unConcrete arrA) (unConcrete arrB)
 
-static_conv2dSameVjpInpHandwrittenVectorized
+static_conv2dPreservingVjpInpHandwrittenVectorized
   :: forall nImgs nCinp nCout nAh nAw nKh nKw shK shA shB r.
      ( NumScalar r, Differentiable r
      , shK ~ '[nCout, nCinp, nKh, nKw]
@@ -1243,17 +1243,17 @@ static_conv2dSameVjpInpHandwrittenVectorized
   -> Nested.Shaped shA r
   -> Nested.Shaped shB r
   -> Bool
-static_conv2dSameVjpInpHandwrittenVectorized SNat SNat SNat SNat SNat SNat SNat
+static_conv2dPreservingVjpInpHandwrittenVectorized SNat SNat SNat SNat SNat SNat SNat
                                              arrK !_arrA arrB =
   let dInp :: Concrete (TKS shA r)
       dInp = interpretAstFull emptyEnv
-             $ conv2dSame_dInp (sconcrete arrK) (sconcrete arrB)
+             $ conv2dPreserving_dInp (sconcrete arrK) (sconcrete arrB)
   in allClose dInp dInp 1e-5
 
-quickcheck_conv2dSameVjpInpHandwrittenVectorized
+quickcheck_conv2dPreservingVjpInpHandwrittenVectorized
   :: forall r. (NumScalar r, Differentiable r)
   => Property
-quickcheck_conv2dSameVjpInpHandwrittenVectorized =
+quickcheck_conv2dPreservingVjpInpHandwrittenVectorized =
   forAll (choose (3, 3)) $ \nImgs' ->
   forAll (choose (3, 3)) $ \nCinp' ->
   forAll (choose (3, 3)) $ \nCout' ->
@@ -1275,11 +1275,11 @@ quickcheck_conv2dSameVjpInpHandwrittenVectorized =
             (arrA, seed3) = randomValue 0.5 seed2
             arrB :: Concrete (TKS '[nImgs, nCout, nAh, nAw] r)
             (arrB, _) = randomValue 0.5 seed3
-        in static_conv2dSameVjpInpHandwrittenVectorized
+        in static_conv2dPreservingVjpInpHandwrittenVectorized
              nImgs nCinp nCout nAh nAw nKh nKw
              (unConcrete arrK) (unConcrete arrA) (unConcrete arrB)
 
-static_conv2dSameVjpInpSymbolic
+static_conv2dPreservingVjpInpSymbolic
   :: forall nImgs nCinp nCout nAh nAw nKh nKw shK shA shB r.
      ( NumScalar r, Differentiable r
      , shK ~ '[nCout, nCinp, nKh, nKw]
@@ -1291,17 +1291,17 @@ static_conv2dSameVjpInpSymbolic
   -> Nested.Shaped shA r
   -> Nested.Shaped shB r
   -> Bool
-static_conv2dSameVjpInpSymbolic SNat SNat SNat SNat SNat SNat SNat
+static_conv2dPreservingVjpInpSymbolic SNat SNat SNat SNat SNat SNat SNat
                                 arrK arrA arrB =
   let vjpInp :: Concrete (TKS shA r)
-      vjpInp = vjp (conv2dSameS (sconcrete arrK))
+      vjpInp = vjp (conv2dPreservingS (sconcrete arrK))
                    (sconcrete arrA) (sconcrete arrB)
   in allClose vjpInp vjpInp 1e-5
 
-quickcheck_conv2dSameVjpInpSymbolic
+quickcheck_conv2dPreservingVjpInpSymbolic
   :: forall r. (NumScalar r, Differentiable r)
   => Property
-quickcheck_conv2dSameVjpInpSymbolic =
+quickcheck_conv2dPreservingVjpInpSymbolic =
   forAll (choose (3, 3)) $ \nImgs' ->
   forAll (choose (3, 3)) $ \nCinp' ->
   forAll (choose (3, 3)) $ \nCout' ->
@@ -1323,11 +1323,11 @@ quickcheck_conv2dSameVjpInpSymbolic =
             (arrA, seed3) = randomValue 0.5 seed2
             arrB :: Concrete (TKS '[nImgs, nCout, nAh, nAw] r)
             (arrB, _) = randomValue 0.5 seed3
-        in static_conv2dSameVjpInpSymbolic
+        in static_conv2dPreservingVjpInpSymbolic
              nImgs nCinp nCout nAh nAw nKh nKw
              (unConcrete arrK) (unConcrete arrA) (unConcrete arrB)
 
-static_conv2dSameVjpInpConcrete
+static_conv2dPreservingVjpInpConcrete
   :: forall nImgs nCinp nCout nAh nAw nKh nKw shK shA shB r.
      ( NumScalar r, Differentiable r
      , shK ~ '[nCout, nCinp, nKh, nKw]
@@ -1339,18 +1339,18 @@ static_conv2dSameVjpInpConcrete
   -> Nested.Shaped shA r
   -> Nested.Shaped shB r
   -> Bool
-static_conv2dSameVjpInpConcrete SNat SNat SNat SNat SNat SNat SNat
+static_conv2dPreservingVjpInpConcrete SNat SNat SNat SNat SNat SNat SNat
                                 arrK arrA arrB =
   let cvjpInp :: Concrete (TKS shA r)
       cvjpInp = cvjp @_ @_ @_ @Concrete
-                     (conv2dSameS (sconcrete arrK))
+                     (conv2dPreservingS (sconcrete arrK))
                      (sconcrete arrA) (sconcrete arrB)
   in allClose cvjpInp cvjpInp 1e-5
 
-quickcheck_conv2dSameVjpInpConcrete
+quickcheck_conv2dPreservingVjpInpConcrete
   :: forall r. (NumScalar r, Differentiable r)
   => Property
-quickcheck_conv2dSameVjpInpConcrete =
+quickcheck_conv2dPreservingVjpInpConcrete =
   forAll (choose (3, 3)) $ \nImgs' ->
   forAll (choose (3, 3)) $ \nCinp' ->
   forAll (choose (3, 3)) $ \nCout' ->
@@ -1372,7 +1372,7 @@ quickcheck_conv2dSameVjpInpConcrete =
             (arrA, seed3) = randomValue 0.5 seed2
             arrB :: Concrete (TKS '[nImgs, nCout, nAh, nAw] r)
             (arrB, _) = randomValue 0.5 seed3
-        in static_conv2dSameVjpInpConcrete
+        in static_conv2dPreservingVjpInpConcrete
              nImgs nCinp nCout nAh nAw nKh nKw
              (unConcrete arrK) (unConcrete arrA) (unConcrete arrB)
 
@@ -1418,7 +1418,7 @@ sizedSymbolicPerCall =
   property $ \seed0 ->
     let (arrK, arrA, arrB) = benchData @nAw @Double seed0
         v :: Concrete (TKS '[3, 3, 3, 3] Double)
-        v = vjp (`conv2dSameS` sconcrete (unConcrete arrA))
+        v = vjp (`conv2dPreservingS` sconcrete (unConcrete arrA))
                 (sconcrete (unConcrete arrK)) (sconcrete (unConcrete arrB))
     in allClose v v 1e-5
 
@@ -1427,7 +1427,7 @@ sizedSymbolicAmortized =
   let (arrK0, arrA0, _) = benchData @nAw @Double 1
       -- Built once and shared as a thunk across every property run.
       art = simplifyArtifactRev
-            $ vjpArtifact (`conv2dSameS` sconcrete (unConcrete arrA0))
+            $ vjpArtifact (`conv2dPreservingS` sconcrete (unConcrete arrA0))
                           (sconcrete (unConcrete arrK0)
                            :: Concrete (TKS '[3, 3, 3, 3] Double))
   in property $ \seed0 ->
@@ -1443,7 +1443,7 @@ sizedHandwrittenVectorized =
     let (_, arrA, arrB) = benchData @nAw @Double seed0
         v :: Concrete (TKS '[3, 3, 3, 3] Double)
         v = interpretAstFull emptyEnv
-            $ conv2dSame_dKrn @3 @3 @3 @nAw @nAw @3 @3
+            $ conv2dPreserving_dKrn @3 @3 @3 @nAw @nAw @3 @3
                               (sconcrete (unConcrete arrA))
                               (sconcrete (unConcrete arrB))
     in allClose v v 1e-5
@@ -1455,7 +1455,7 @@ sizedSymbolicPerCallInp =
   property $ \seed0 ->
     let (arrK, arrA, arrB) = benchData @nAw @Double seed0
         v :: Concrete (TKS '[3, 3, nAw, nAw] Double)
-        v = vjp (conv2dSameS (sconcrete (unConcrete arrK)))
+        v = vjp (conv2dPreservingS (sconcrete (unConcrete arrK)))
                 (sconcrete (unConcrete arrA)) (sconcrete (unConcrete arrB))
     in allClose v v 1e-5
 
@@ -1463,7 +1463,7 @@ sizedSymbolicAmortizedInp :: forall nAw. KnownNat nAw => Property
 sizedSymbolicAmortizedInp =
   let (arrK0, arrA0, _) = benchData @nAw @Double 1
       art = simplifyArtifactRev
-            $ vjpArtifact (conv2dSameS (sconcrete (unConcrete arrK0)))
+            $ vjpArtifact (conv2dPreservingS (sconcrete (unConcrete arrK0)))
                           (sconcrete (unConcrete arrA0)
                            :: Concrete (TKS '[3, 3, nAw, nAw] Double))
   in property $ \seed0 ->
@@ -1479,7 +1479,7 @@ sizedHandwrittenVectorizedInp =
     let (arrK, _, arrB) = benchData @nAw @Double seed0
         v :: Concrete (TKS '[3, 3, nAw, nAw] Double)
         v = interpretAstFull emptyEnv
-            $ conv2dSame_dInp @3 @3 @3 @nAw @nAw @3 @3
+            $ conv2dPreserving_dInp @3 @3 @3 @nAw @nAw @3 @3
                               (sconcrete (unConcrete arrK))
                               (sconcrete (unConcrete arrB))
     in allClose v v 1e-5

--- a/test/simplified/TestConvQuickCheck.hs
+++ b/test/simplified/TestConvQuickCheck.hs
@@ -5,7 +5,10 @@
 -- vs handwritten derivatives. The matching deterministic (non-QuickCheck)
 -- gradient-correctness checks live in "TestConvCorrect"; the shared
 -- random-data helpers and handwritten gradients exported below are what that
--- module reuses.
+-- module reuses. The criterion counterpart of the preserving-convolution poor
+-- man's benchmarks (the shrinking and padded ones have none) is
+-- bench/ConvVjpBench.hs; its per-call numbers are the citable ones, the
+-- tasty totals here being wall-clock over 100 runs on a coarse timer.
 module TestConvQuickCheck
   ( testTrees
     -- * Shared with "TestConvCorrect"
@@ -80,7 +83,7 @@ testTrees =
   , testProperty "conv2dPreservingVjp Bench dKrn Handwritten"
                  (quickcheck_conv2dPreservingVjpKrnHandwritten @Double)
   , testProperty "conv2dPreservingVjp Bench dKrn HandwrittenVectorized"
-                 (quickcheck_conv2dPreservingVjpKrnHandwrittenVectorized @Double)
+      (quickcheck_conv2dPreservingVjpKrnHandwrittenVectorized @Double)
   , testProperty "conv2dPreservingVjp Bench dKrn Symbolic"
                  (quickcheck_conv2dPreservingVjpKrnSymbolic @Double)
   , testProperty "conv2dPreservingVjp Bench dKrn Concrete"
@@ -88,7 +91,7 @@ testTrees =
   , testProperty "conv2dPreservingVjp Bench dInp Handwritten"
                  (quickcheck_conv2dPreservingVjpInpHandwritten @Double)
   , testProperty "conv2dPreservingVjp Bench dInp HandwrittenVectorized"
-                 (quickcheck_conv2dPreservingVjpInpHandwrittenVectorized @Double)
+      (quickcheck_conv2dPreservingVjpInpHandwrittenVectorized @Double)
   , testProperty "conv2dPreservingVjp Bench dInp Symbolic"
                  (quickcheck_conv2dPreservingVjpInpSymbolic @Double)
   , testProperty "conv2dPreservingVjp Bench dInp Concrete"
@@ -282,7 +285,8 @@ flip42 arr =
 
 -- | Hand-written reverse derivative of full convolution with respect
 -- to the input image.
--- Example code that horde-ad generates for the same is in testPreservingCNNOPP0bW.
+-- Example code that horde-ad generates for the same is in
+-- testPreservingCNNOPP0bW.
 conv2dPreserving_dInp
   :: forall nImgs nCinp nCout nAh nAw nKh nKw shK shA shB shB1
             target r.
@@ -308,14 +312,19 @@ conv2dPreserving_dInp arrK arrB =
                           [iCinp, 0 , 0, 0]
       in sfromK $ sdot0 arrBt arrKt
     _ -> error "conv2dPreserving_dInp: impossible pattern needlessly required"
--- Note that
--- > ... in conv2dPreservingS (stranspose @'[1, 0] arrKFlipped) arrB
--- type-checks above, but test fails due to the lack of @- nKh + 1@.
+-- Note that writing the body as
+-- > conv2dPreservingS (stranspose @'[1, 0] arrKFlipped) arrB
+-- type-checks (the same-size convolution keeps the shapes equal), but the
+-- test catches it: conv2dPreservingS's window extends forward from each
+-- position, while the adjoint's must extend backward — the
+-- @- nKh + 1@/@- nKw + 1@ offsets in the slice above.
 
 -- | Hand-written reverse derivative of full convolution with respect
 -- to the kernels.
--- This code vectorized is pretty-printed in test testPreservingCNNOPPKrnHandwritten.
--- Example code that horde-ad generates for the same is in testPreservingCNNOPP0cW.
+-- This code vectorized is pretty-printed in test
+-- testPreservingCNNOPPKrnHandwritten.
+-- Example code that horde-ad generates for the same is in
+-- testPreservingCNNOPP0cW.
 conv2dPreserving_dKrn
   :: forall nImgs nCinp nCout nAh nAw nKh nKw shK shA shB shB1
             target r.
@@ -395,9 +404,11 @@ static_conv2dPreservingVjp
   -> Bool
 static_conv2dPreservingVjp SNat SNat SNat SNat SNat SNat SNat arrK arrA arrB =
   let -- Compare the AD version against the manual derivative.
-      -- Note that manual versions don't take one of the arguments (the point
-      -- at which the gradient is taken), because maths (something about
-      -- convolution being linear and so gradient the same everywhere).
+      -- Note that the manual versions don't take one of the arguments (the
+      -- point at which the gradient is taken): convolution is linear in each
+      -- argument separately, so the gradient with respect to one argument
+      -- does not depend on that argument's value — only on the other
+      -- argument and the incoming cotangent, which they do take.
       -- First, the gradient wrt the input image taken at point @arrA@.
       dInp :: Concrete (TKS shA r)
       dInp = conv2dPreserving_dInp
@@ -558,9 +569,7 @@ static_conv2dShrinkingVjp
   -> Bool
 static_conv2dShrinkingVjp SNat SNat SNat SNat SNat SNat SNat arrK arrA arrB =
   let -- Compare the AD version against the manual derivative.
-      -- Note that manual versions don't take one of the arguments (the point
-      -- at which the gradient is taken), because maths (something about
-      -- convolution being linear and so gradient the same everywhere).
+      -- See the note on the manual versions in static_conv2dPreservingVjp.
       -- First, the gradient wrt the input image taken at point @arrA@.
       dInp :: Concrete (TKS shA r)
       dInp = conv2dShrinking_dInp
@@ -728,9 +737,7 @@ static_conv2dPaddedVjp
   -> Bool
 static_conv2dPaddedVjp SNat SNat SNat SNat SNat SNat SNat arrK arrA arrB =
   let -- Compare the AD version against the manual derivative.
-      -- Note that manual versions don't take one of the arguments (the point
-      -- at which the gradient is taken), because maths (something about
-      -- convolution being linear and so gradient the same everywhere).
+      -- See the note on the manual versions in static_conv2dPreservingVjp.
       -- First, the gradient wrt the input image taken at point @arrA@.
       dInp :: Concrete (TKS shA r)
       dInp = conv2dPadded_dInp
@@ -805,7 +812,7 @@ static_conv2dPreservingJvp
   -> Nested.Shaped shA r -> Nested.Shaped shA r
   -> Bool
 static_conv2dPreservingJvp SNat SNat SNat SNat SNat SNat SNat
-                     arrK arrK2 arrA arrA2 =
+                           arrK arrK2 arrA arrA2 =
   let dInp :: Concrete (TKS shB r)
       dInp = conv2dPreservingS (sconcrete arrK) (sconcrete arrA2)
       jvpInp = jvp (conv2dPreservingS (sconcrete arrK))
@@ -1005,7 +1012,7 @@ static_conv2dPreservingVjpKrnHandwritten
   -> Nested.Shaped shB r
   -> Bool
 static_conv2dPreservingVjpKrnHandwritten SNat SNat SNat SNat SNat SNat SNat
-                                   !_arrK arrA arrB =
+                                         !_arrK arrA arrB =
   let dKrn :: Concrete (TKS shK r)
       dKrn = conv2dPreserving_dKrn (sconcrete arrA) (sconcrete arrB)
   in allClose dKrn dKrn 1e-5
@@ -1051,8 +1058,8 @@ static_conv2dPreservingVjpKrnHandwrittenVectorized
   -> Nested.Shaped shA r
   -> Nested.Shaped shB r
   -> Bool
-static_conv2dPreservingVjpKrnHandwrittenVectorized SNat SNat SNat SNat SNat SNat SNat
-                                             !_arrK arrA arrB =
+static_conv2dPreservingVjpKrnHandwrittenVectorized
+  SNat SNat SNat SNat SNat SNat SNat !_arrK arrA arrB =
   let dKrn :: Concrete (TKS shK r)
       dKrn = interpretAstFull emptyEnv
              $ conv2dPreserving_dKrn (sconcrete arrA) (sconcrete arrB)
@@ -1100,7 +1107,7 @@ static_conv2dPreservingVjpKrnSymbolic
   -> Nested.Shaped shB r
   -> Bool
 static_conv2dPreservingVjpKrnSymbolic SNat SNat SNat SNat SNat SNat SNat
-                                arrK arrA arrB =
+                                      arrK arrA arrB =
   let vjpKrn :: Concrete (TKS shK r)
       vjpKrn = vjp (`conv2dPreservingS` sconcrete arrA)
                    (sconcrete arrK) (sconcrete arrB)
@@ -1148,7 +1155,7 @@ static_conv2dPreservingVjpKrnConcrete
   -> Nested.Shaped shB r
   -> Bool
 static_conv2dPreservingVjpKrnConcrete SNat SNat SNat SNat SNat SNat SNat
-                                arrK arrA arrB =
+                                      arrK arrA arrB =
   let cvjpKrn :: Concrete (TKS shK r)
       cvjpKrn = cvjp @_ @_ @_ @Concrete
                      (`conv2dPreservingS` sconcrete arrA)
@@ -1197,7 +1204,7 @@ static_conv2dPreservingVjpInpHandwritten
   -> Nested.Shaped shB r
   -> Bool
 static_conv2dPreservingVjpInpHandwritten SNat SNat SNat SNat SNat SNat SNat
-                                   arrK !_arrA arrB =
+                                         arrK !_arrA arrB =
   let dInp :: Concrete (TKS shA r)
       dInp = conv2dPreserving_dInp (sconcrete arrK) (sconcrete arrB)
   in allClose dInp dInp 1e-5
@@ -1243,8 +1250,8 @@ static_conv2dPreservingVjpInpHandwrittenVectorized
   -> Nested.Shaped shA r
   -> Nested.Shaped shB r
   -> Bool
-static_conv2dPreservingVjpInpHandwrittenVectorized SNat SNat SNat SNat SNat SNat SNat
-                                             arrK !_arrA arrB =
+static_conv2dPreservingVjpInpHandwrittenVectorized
+  SNat SNat SNat SNat SNat SNat SNat arrK !_arrA arrB =
   let dInp :: Concrete (TKS shA r)
       dInp = interpretAstFull emptyEnv
              $ conv2dPreserving_dInp (sconcrete arrK) (sconcrete arrB)
@@ -1292,7 +1299,7 @@ static_conv2dPreservingVjpInpSymbolic
   -> Nested.Shaped shB r
   -> Bool
 static_conv2dPreservingVjpInpSymbolic SNat SNat SNat SNat SNat SNat SNat
-                                arrK arrA arrB =
+                                      arrK arrA arrB =
   let vjpInp :: Concrete (TKS shA r)
       vjpInp = vjp (conv2dPreservingS (sconcrete arrK))
                    (sconcrete arrA) (sconcrete arrB)
@@ -1340,7 +1347,7 @@ static_conv2dPreservingVjpInpConcrete
   -> Nested.Shaped shB r
   -> Bool
 static_conv2dPreservingVjpInpConcrete SNat SNat SNat SNat SNat SNat SNat
-                                arrK arrA arrB =
+                                      arrK arrA arrB =
   let cvjpInp :: Concrete (TKS shA r)
       cvjpInp = cvjp @_ @_ @_ @Concrete
                      (conv2dPreservingS (sconcrete arrK))
@@ -1395,9 +1402,13 @@ quickcheck_conv2dPreservingVjpInpConcrete =
 -- * @HandwrittenVectorized@ is the handwritten gradient vectorized and
 --   interpreted per run, for comparison.
 --
--- At small sizes the build tax roughly doubles the per-call symbolic time
--- while the amortized cost is competitive with the handwritten one; as the
--- size grows the fixed tax shrinks relative to interpretation.
+-- At small sizes the build tax roughly doubles the per-call symbolic time;
+-- as the size grows the fixed tax shrinks relative to interpretation.
+-- @HandwrittenVectorized@ has no amortized variant to pair with
+-- @SymbolicAmortized@ — with the cotangent embedded as a constant the term
+-- must be rebuilt for every new cotangent — so comparing those two mixes
+-- pipeline stages; the stage-for-stage S/H comparison, with the cotangent
+-- kept as a variable on both sides, lives in bench/ConvVjpBench.hs.
 
 -- | Kernel, input and output-gradient of the poor man's benchmark shapes
 -- (@nImgs = nCinp = nCout = 3@, @nKh = nKw = 3@, @nAh = nAw@), from one seed.
@@ -1444,8 +1455,8 @@ sizedHandwrittenVectorized =
         v :: Concrete (TKS '[3, 3, 3, 3] Double)
         v = interpretAstFull emptyEnv
             $ conv2dPreserving_dKrn @3 @3 @3 @nAw @nAw @3 @3
-                              (sconcrete (unConcrete arrA))
-                              (sconcrete (unConcrete arrB))
+                                    (sconcrete (unConcrete arrA))
+                                    (sconcrete (unConcrete arrB))
     in allClose v v 1e-5
 
 -- The same trio, for the input gradient (the @sscatter@ path).
@@ -1480,8 +1491,8 @@ sizedHandwrittenVectorizedInp =
         v :: Concrete (TKS '[3, 3, nAw, nAw] Double)
         v = interpretAstFull emptyEnv
             $ conv2dPreserving_dInp @3 @3 @3 @nAw @nAw @3 @3
-                              (sconcrete (unConcrete arrK))
-                              (sconcrete (unConcrete arrB))
+                                    (sconcrete (unConcrete arrK))
+                                    (sconcrete (unConcrete arrB))
     in allClose v v 1e-5
 
 
@@ -1489,7 +1500,7 @@ sizedHandwrittenVectorizedInp =
 --
 -- Kernel is 3x3, so with output size @nAw@ the input is @(nAw+2)^2@ (the
 -- output shrinks by the kernel size minus one). The poor man's benchmarks
--- mirror the @Same@ ones above.
+-- mirror the @Preserving@ ones above.
 
 benchDataShrinking
   :: forall nAw r. (KnownNat nAw, NumScalar r)
@@ -1533,7 +1544,7 @@ shrinkingHandwrittenVectorized =
     let (_, arrA, arrB) = benchDataShrinking @nAw @Double seed0
         v :: Concrete (TKS '[3, 3, 3, 3] Double)
         v = interpretAstFull emptyEnv
-            -- @2 @2 here, not @3 @3 as for Same: the shrinking and padded
+            -- @2 @2 here, not @3 @3 as for Preserving: the shrinking and padded
             -- handwritten gradients take nKh1 = nKh - 1, so 2 is a 3x3 kernel.
             $ conv2dShrinking_dKrn @3 @3 @3 @nAw @nAw @2 @2
                                    (sconcrete (unConcrete arrA))
@@ -1579,7 +1590,7 @@ shrinkingHandwrittenVectorizedInp =
 -- * The padded convolution variant
 --
 -- Kernel is 3x3, so with input size @nAw@ the output is @(nAw+2)^2@ (the
--- output grows). The poor man's benchmarks mirror the @Same@ ones above.
+-- output grows). The poor man's benchmarks mirror the @Preserving@ ones above.
 
 benchDataPadded
   :: forall nAw r. (KnownNat nAw, NumScalar r)

--- a/test/simplified/TestConvSimplified.hs
+++ b/test/simplified/TestConvSimplified.hs
@@ -27,7 +27,7 @@ import HordeAd.Core.Delta
 import HordeAd.Core.Ops
 import HordeAd.Core.OpsAst
 
-import TestConvQuickCheck (conv2dSame_dKrn)
+import TestConvQuickCheck (conv2dPreserving_dKrn)
 
 import CrossTesting
 import EqEpsilon
@@ -154,10 +154,11 @@ testTrees =
   , testCase "minimizedPaddedCNNOPPLet" testPaddedCNNOPPLet
   , testCase "minimizedPaddedCNNOPPLet2" testPaddedCNNOPPLet2
   , testCase "minimizedPaddedCNNOPP2" testPaddedCNNOPP2
-  , testCase "minimizedSameCNNOPPKrnHandwritten" testSameCNNOPPKrnHandwritten
-  , testCase "minimizedSameCNNOPP0cW" testSameCNNOPP0cW
-  , testCase "minimizedSameCNNOPP0bW" testSameCNNOPP0bW
-  , testCase "minimizedSameCNNOPP1bW" testSameCNNOPP1bW
+  , testCase "minimizedPreservingCNNOPPKrnHandwritten"
+             testPreservingCNNOPPKrnHandwritten
+  , testCase "minimizedPreservingCNNOPP0cW" testPreservingCNNOPP0cW
+  , testCase "minimizedPreservingCNNOPP0bW" testPreservingCNNOPP0bW
+  , testCase "minimizedPreservingCNNOPP1bW" testPreservingCNNOPP1bW
   , testCase "minimizedShrinkingCNNOPP0cW" testShrinkingCNNOPP0cW
   , testCase "minimizedShrinkingCNNOPP0bW" testShrinkingCNNOPP0bW
   , testCase "minimizedShrinkingCNNOPP1bW" testShrinkingCNNOPP1bW
@@ -181,17 +182,17 @@ testTrees =
 conv2d1
   :: (ADReady target, NumScalar r, Differentiable r)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2d1 = conv2dSame $ rconcrete $ Nested.rfromListPrimLinear (fromList [1, 1, 1, 1]) [-0.2]
+conv2d1 = conv2dPreserving $ rconcrete $ Nested.rfromListPrimLinear (fromList [1, 1, 1, 1]) [-0.2]
 
 conv2dA
   :: (ADReady target, NumScalar r, Differentiable r)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2dA = conv2dSame $ rconcrete $ Nested.rfromListPrimLinear (fromList [1, 2, 1, 1]) [-0.2, 25.0003]
+conv2dA = conv2dPreserving $ rconcrete $ Nested.rfromListPrimLinear (fromList [1, 2, 1, 1]) [-0.2, 25.0003]
 
 conv2dB
   :: (ADReady target, NumScalar r, Differentiable r)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2dB = conv2dSame (rconcrete $ unConcrete t16b)
+conv2dB = conv2dPreserving (rconcrete $ unConcrete t16b)
 
 testKonstG0Rev :: Assertion
 testKonstG0Rev =
@@ -210,7 +211,7 @@ testKonstG0TinyS =
   assertEqualUpToEpsilon' 1e-10
     (ringestData [1, 1, 1, 1] [582665.99432])
     (rev' @Double @4
-          (conv2dSame $ rreplicate0N [1, 1, 1, 1] (rsum0 (rconcrete $ unConcrete t16b)))
+          (conv2dPreserving $ rreplicate0N [1, 1, 1, 1] (rsum0 (rconcrete $ unConcrete t16b)))
           (ringestData [1, 1, 1, 1] [0]))
 
 testKonstG0TinyA :: Assertion
@@ -228,27 +229,27 @@ testKonstG0LittleA =
 conv2dC
   :: (ADReady target, NumScalar r, Differentiable r)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2dC = flip conv2dSame (rconcrete $ unConcrete t16b)
+conv2dC = flip conv2dPreserving (rconcrete $ unConcrete t16b)
 
 conv2dB128b
   :: (ADReady target, NumScalar r, Differentiable r)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2dB128b = conv2dSame (rconcrete $ unConcrete t128b)
+conv2dB128b = conv2dPreserving (rconcrete $ unConcrete t128b)
 
 conv2dC128b
   :: (ADReady target, NumScalar r, Differentiable r)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2dC128b = flip conv2dSame (rconcrete $ unConcrete t128b)
+conv2dC128b = flip conv2dPreserving (rconcrete $ unConcrete t128b)
 
 conv2dB128c
   :: (ADReady target, NumScalar r, Differentiable r)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2dB128c = conv2dSame (rconcrete $ unConcrete t128c)
+conv2dB128c = conv2dPreserving (rconcrete $ unConcrete t128c)
 
 conv2dC128c
   :: (ADReady target, NumScalar r, Differentiable r)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2dC128c = flip conv2dSame (rconcrete $ unConcrete t128c)
+conv2dC128c = flip conv2dPreserving (rconcrete $ unConcrete t128c)
 
 testReplicate0Rev :: Assertion
 testReplicate0Rev =
@@ -267,7 +268,7 @@ testReplicate0TinyS =
   assertEqualUpToEpsilon' 1e-10
     (ringestData [1, 1, 1, 1] [582665.99432])
     (rev' @Double @4
-          (conv2dSame $ rreplicate0N [1, 1, 1, 1] (rsum0 (rconcrete $ unConcrete t16b)))
+          (conv2dPreserving $ rreplicate0N [1, 1, 1, 1] (rsum0 (rconcrete $ unConcrete t16b)))
           (ringestData [1, 1, 1, 1] [0]))
 
 testReplicate0TinyA :: Assertion
@@ -469,10 +470,10 @@ testKonstNotBigC128cb =
 --
 -- BTW, the indexing lower bounds in the code are spurious,
 -- so they get simplified away in the resulting AST program.
-conv2dSameL
+conv2dPreservingL
   :: (ADReady target, NumScalar r)
   => target (TKR 4 r) -> target (TKR 4 r) -> target (TKR 4 r)
-conv2dSameL arrK arrA =
+conv2dPreservingL arrK arrA =
   let [nImgs, nCinpA, nAh, nAw] = rshape arrA
       [nCoutK, nCinpK, nKh, nKw] = rshape arrK
       nCinp = assert (nCinpA == nCinpK `blame` (nCinpA, nCinpK)) nCinpA
@@ -483,7 +484,7 @@ conv2dSameL arrK arrA =
       let arrAt = slicezL shK1 arrA [iImg, 0, iBh, iBw]
           arrKt = slicezL shK1 arrK [iCout, 0, 0, 0]
       in rfromK $ rdot0 arrAt arrKt
-    _ -> error "conv2dSameL: impossible pattern needlessly required"
+    _ -> error "conv2dPreservingL: impossible pattern needlessly required"
 
 -- | Slice a section out of a tensor,
 --   given a base offset and shape of the section.
@@ -524,43 +525,43 @@ within0 sh ix =
 conv2d1Laborious
   :: (ADReady target, NumScalar r, Differentiable r)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2d1Laborious = conv2dSameL $ rconcrete $ Nested.rfromListPrimLinear (fromList [1, 1, 1, 1]) [-0.2]
+conv2d1Laborious = conv2dPreservingL $ rconcrete $ Nested.rfromListPrimLinear (fromList [1, 1, 1, 1]) [-0.2]
 
 conv2dALaborious
   :: (ADReady target, NumScalar r, Differentiable r)
   => target (TKR 4 r) -> target (TKR 4 r)
 conv2dALaborious =
-  conv2dSameL $ rconcrete $ Nested.rfromListPrimLinear (fromList [1, 2, 1, 1]) [-0.2, 25.0003]
+  conv2dPreservingL $ rconcrete $ Nested.rfromListPrimLinear (fromList [1, 2, 1, 1]) [-0.2, 25.0003]
 
 conv2dBLaborious
   :: (ADReady target, NumScalar r, Differentiable r)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2dBLaborious = conv2dSameL (rconcrete $ unConcrete t16b)
+conv2dBLaborious = conv2dPreservingL (rconcrete $ unConcrete t16b)
 
 conv2dCLaborious
   :: (ADReady target, NumScalar r, Differentiable r)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2dCLaborious = flip conv2dSameL (rconcrete $ unConcrete t16b)
+conv2dCLaborious = flip conv2dPreservingL (rconcrete $ unConcrete t16b)
 
 conv2dBLaborious128b
   :: (ADReady target, NumScalar r, Differentiable r)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2dBLaborious128b = conv2dSameL (rconcrete $ unConcrete t128b)
+conv2dBLaborious128b = conv2dPreservingL (rconcrete $ unConcrete t128b)
 
 conv2dCLaborious128b
   :: (ADReady target, NumScalar r, Differentiable r)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2dCLaborious128b = flip conv2dSameL (rconcrete $ unConcrete t128b)
+conv2dCLaborious128b = flip conv2dPreservingL (rconcrete $ unConcrete t128b)
 
 conv2dBLaborious128c
   :: (ADReady target, NumScalar r, Differentiable r)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2dBLaborious128c = conv2dSameL (rconcrete $ unConcrete t128c)
+conv2dBLaborious128c = conv2dPreservingL (rconcrete $ unConcrete t128c)
 
 conv2dCLaborious128c
   :: (ADReady target, NumScalar r, Differentiable r)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2dCLaborious128c = flip conv2dSameL (rconcrete $ unConcrete t128c)
+conv2dCLaborious128c = flip conv2dPreservingL (rconcrete $ unConcrete t128c)
 
 testReplicate0RevLaborious :: Assertion
 testReplicate0RevLaborious =
@@ -579,7 +580,7 @@ testReplicate0TinySLaborious =
   assertEqualUpToEpsilon' 1e-10
     (ringestData [1, 1, 1, 1] [582665.99432])
     (rev' @Double @4
-          (conv2dSameL $ rreplicate0N [1, 1, 1, 1] (rsum0 (rconcrete $ unConcrete t16b)))
+          (conv2dPreservingL $ rreplicate0N [1, 1, 1, 1] (rsum0 (rconcrete $ unConcrete t16b)))
           (ringestData [1, 1, 1, 1] [0]))
 
 testReplicate0TinyALaborious :: Assertion
@@ -781,7 +782,7 @@ testKonstNotBigCLaborious128cb =
 --   and all input points are read the same number of times.
 --
 --   The same result could be accomplished by tweaking indexes slightly
---   in conv2dSame, but here additionally all bounds checks in the code
+--   in conv2dPreserving, but here additionally all bounds checks in the code
 --   are spurious and will be simplified away in the resulting AST program.
 conv2dPaddedB
   :: forall target r. (ADReady target, NumScalar r)
@@ -1259,7 +1260,7 @@ testCNNOPP1e = do
                      (TKProduct (TKR 4 Double) (TKR 4 Double))
         -> AstTensor AstMethodLet FullSpan
                      (TKR 4 Double)
-      f v = conv2dSameL (tproject1 v) (tproject2 v)
+      f v = conv2dPreservingL (tproject1 v) (tproject2 v)
       ftk = FTKProduct (FTKR (2 :$: 2 :$: 2 :$: 2 :$: ZSR) FTKScalar)
                        (FTKR (2 :$: 2 :$: 2 :$: 2 :$: ZSR) FTKScalar)
       (artifactRev, _) =
@@ -1301,19 +1302,19 @@ maxPool2dUnpadded2
 maxPool2dUnpadded2 a =
   rbuild [2, 2, 2, 2] $ \case
     [_, _, iBh, iBw] ->
-      let arrt = slicez2 (conv2dSame2 a) [iBw, 1, 2 * iBh, 2 * iBw]
+      let arrt = slicez2 (conv2dPreserving2 a) [iBw, 1, 2 * iBh, 2 * iBw]
       in rmaximum2 arrt
     _ -> error "maxPool2dUnpadded2: impossible pattern needlessly required"
 
-conv2dSame2
+conv2dPreserving2
   :: (target ~ AstTensor AstMethodLet FullSpan, r ~ Double)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2dSame2 a =
+conv2dPreserving2 a =
   rbuild [3, 3, 2, 2] $ \case
     [iImg, _, iBh, iBw] ->
       let arrAt = slicez2 a [iImg, 0, iBh, iBw]
       in rindex @_ @0 arrAt [0, iBw, iBw, 0]
-    _ -> error "conv2dSame2: impossible pattern needlessly required"
+    _ -> error "conv2dPreserving2: impossible pattern needlessly required"
 
 slicez2
   :: (target ~ AstTensor AstMethodLet FullSpan, r ~ Double, n ~ 4)
@@ -1339,7 +1340,7 @@ testCNNOPP3 = do
                        (rconcrete $ Nested.rscalar 7
                         :: AstTensor AstMethodLet PrimalSpan (TKR 0 Double))
       afcnn2T :: AstTensor AstMethodLet FullSpan (TKR 4 Double)
-      afcnn2T = maxPool2dUnpadded33 $ conv2dSame3 blackGlyph
+      afcnn2T = maxPool2dUnpadded33 $ conv2dPreserving3 blackGlyph
   printAstPretty (simplifyInlineContract afcnn2T)
     @?= "rfromPlain (rfromS (sfromVector @2 (fromList [str (sgather1 @2 (sgather @[2, 2, 2] (sfromVector @2 (fromList [sgather @[2, 2] (sappend (sreplicate @1 (stranspose @[0, 2, 1] (sgather @[2, 2] (stranspose @[3, 0, 2, 1] (sgather @[2, 2] (stranspose @[3, 0, 1, 2] (sgather @[2, 2] (sconcrete (sreplicate [2,2,2] 7.0)) (\\[i97, i99] -> [remH i97 4 + i99]))) (\\[i101, i103] -> [i101 + i103, i101]))) (\\[i33, i15] -> [i33 + i15, i33])))) (sconcrete (sreplicate [1,2,2,2,2] 0.0))) (\\[i32, i27] -> [i27, i32, i27, i32]), sconcrete (sreplicate [2,2,2] 0.0)])) (\\[i31, i28, i26] -> [sconcrete (sfromListLinear [2,2,2] [0,0,1,1,1,1,1,1]) `sindex0` [i31, i28, i26], i31, i28, i26])) (\\i123 -> [remH i123 4])), str (sgather1 @2 (sgather @[2, 2, 2] (sfromVector @2 (fromList [sgather @[2, 2] (sappend (sreplicate @1 (stranspose @[0, 2, 1] (sgather @[2, 2] (stranspose @[3, 0, 2, 1] (sgather @[2, 2] (stranspose @[3, 0, 1, 2] (sgather @[2, 2] (sconcrete (sreplicate [2,2,2] 7.0)) (\\[i127, i129] -> [remH i127 4 + i129]))) (\\[i131, i133] -> [i131 + i133, i131]))) (\\[i33, i15] -> [i33 + i15, i33])))) (sconcrete (sreplicate [1,2,2,2,2] 0.0))) (\\[i32, i27] -> [i27, i32, i27, i32]), sconcrete (sreplicate [2,2,2] 0.0)])) (\\[i31, i28, i26] -> [sconcrete (sfromListLinear [2,2,2] [0,0,1,1,1,1,1,1]) `sindex0` [i31, i28, i26], i31, i28, i26])) (\\i153 -> [remH i153 4]))])))"
   printAstPretty afcnn2T
@@ -1348,7 +1349,7 @@ testCNNOPP3 = do
 testCNNOPP3b :: Assertion
 testCNNOPP3b = do
   resetVarCounter
-  let artifactRev = revArtifactAdapt UseIncomingCotangent (maxPool2dUnpadded33 . conv2dSame3) (FTKR [2, 2, 2, 2] (FTKScalar @Double))
+  let artifactRev = revArtifactAdapt UseIncomingCotangent (maxPool2dUnpadded33 . conv2dPreserving3) (FTKR [2, 2, 2, 2] (FTKScalar @Double))
   printArtifactPrimalPretty (simplifyArtifactRev artifactRev)
     @?= "\\u1 -> rfromS (sfromVector @2 (fromList [str (sgather1 @2 (sgather @[2, 2, 2] (sfromVector @2 (fromList [sgather @[2, 2] (sappend (sreplicate @1 (stranspose @[0, 2, 1] (sgather @[2, 2] (stranspose @[3, 0, 2, 1] (sgather @[2, 2] (stranspose @[3, 0, 1, 2] (sgather @[2, 2] (stranspose @[3, 0, 2, 1] (sfromR u1) !$ [1]) (\\[i255, i257] -> [remH i255 4 + i257]))) (\\[i259, i261] -> [i259 + i261, i259]))) (\\[i159, i160] -> [i159 + i160, i159])))) (sconcrete (sreplicate [1,2,2,2,2] 0.0))) (\\[i161, i162] -> [i162, i161, i162, i161]), sconcrete (sreplicate [2,2,2] 0.0)])) (\\[i163, i164, i165] -> [sconcrete (sfromListLinear [2,2,2] [0,0,1,1,1,1,1,1]) `sindex0` [i163, i164, i165], i163, i164, i165])) (\\i166 -> [remH i166 4])), str (sgather1 @2 (sgather @[2, 2, 2] (sfromVector @2 (fromList [sgather @[2, 2] (sappend (sreplicate @1 (stranspose @[0, 2, 1] (sgather @[2, 2] (stranspose @[3, 0, 2, 1] (sgather @[2, 2] (stranspose @[3, 0, 1, 2] (sgather @[2, 2] (stranspose @[3, 0, 2, 1] (sfromR u1) !$ [1]) (\\[i267, i269] -> [remH i267 4 + i269]))) (\\[i271, i273] -> [i271 + i273, i271]))) (\\[i171, i172] -> [i171 + i172, i171])))) (sconcrete (sreplicate [1,2,2,2,2] 0.0))) (\\[i173, i174] -> [i174, i173, i174, i173]), sconcrete (sreplicate [2,2,2] 0.0)])) (\\[i175, i176, i177] -> [sconcrete (sfromListLinear [2,2,2] [0,0,1,1,1,1,1,1]) `sindex0` [i175, i176, i177], i175, i176, i177])) (\\i178 -> [remH i178 4]))]))"
   printArtifactPrimalPretty artifactRev
@@ -1378,16 +1379,16 @@ maxPool2dUnpadded33 arr =
       in rmaximum3 arrt
     _ -> error "maxPool2dUnpadded33: impossible pattern needlessly required"
 
-conv2dSame3
+conv2dPreserving3
   :: (ADReady target, NumScalar r)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2dSame3 arrA =
+conv2dPreserving3 arrA =
   let shB = [2, 2, 2, 2]
   in rbuild shB $ \case
     [iImg, _, iBh, iBw] ->
       let arrAt = slicez33 shB arrA [iImg `remH` 4, iImg, iImg, 1]
       in rindex @_ @0 arrAt [iBh, iBw, iImg, iBh]
-    _ -> error "conv2dSame3: impossible pattern needlessly required"
+    _ -> error "conv2dPreserving3: impossible pattern needlessly required"
 
 slicez3
   :: (ADReady target, NumScalar r, KnownNat n)
@@ -1448,7 +1449,7 @@ testCNNOPP5 = do
                        (rconcrete $ Nested.rscalar 7
                         :: AstTensor AstMethodLet PrimalSpan (TKR 0 Double))
       afcnn2T :: AstTensor AstMethodLet PrimalSpan (TKR 4 Double)
-      afcnn2T = conv2dSame4 blackGlyph
+      afcnn2T = conv2dPreserving4 blackGlyph
   printAstPretty (simplifyInlineContract afcnn2T)
     @?= "rfromS (sconcrete (sreplicate [1,1,2,2] 7.0))"
   printAstPretty afcnn2T
@@ -1457,7 +1458,7 @@ testCNNOPP5 = do
 testCNNOPP5b :: Assertion
 testCNNOPP5b = do
   resetVarCounter
-  let artifactRev = revArtifactAdapt UseIncomingCotangent conv2dSame4 (FTKR [5, 5, 5, 5] (FTKScalar @Double))
+  let artifactRev = revArtifactAdapt UseIncomingCotangent conv2dPreserving4 (FTKR [5, 5, 5, 5] (FTKScalar @Double))
   printArtifactPrimalPretty (simplifyArtifactRev artifactRev)
     @?= "\\u1 -> rfromS (sreplicateN @[1, 1] (str (sslice (SNat @0) (SNat @2) (str (sslice (SNat @0) (SNat @2) (sfromR u1 !$ [0, 0]))))))"
   printArtifactPrimalPretty artifactRev
@@ -1477,16 +1478,16 @@ maxPool2dUnpadded4 arr =
       in rmaximum3 arrt
     _ -> error "maxPool2dUnpadded4: impossible pattern needlessly required"
 
-conv2dSame4
+conv2dPreserving4
   :: (ADReady target, NumScalar r)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2dSame4 arrA =
+conv2dPreserving4 arrA =
   let shB = [1, 1, 2, 2]
   in rbuild shB $ \case
     [iImg, _, iBh, iBw] ->
       let arrAt = slicez4 shB arrA [iImg, 0, iBh, iBw]
       in rindex @_ @0 arrAt [0, 0, 0, 0]
-    _ -> error "conv2dSame4: impossible pattern needlessly required"
+    _ -> error "conv2dPreserving4: impossible pattern needlessly required"
 
 slicez4
   :: (ADReady target, NumScalar r, KnownNat n)
@@ -1502,7 +1503,7 @@ testCNNOPP6 = do
                        (rconcrete $ Nested.rscalar 7
                         :: AstTensor AstMethodLet PlainSpan (TKR 0 Double))
       afcnn2T :: AstTensor AstMethodLet FullSpan (TKR 4 Double)
-      afcnn2T = maxPool2dUnpadded3 $ conv2dSame3z blackGlyph
+      afcnn2T = maxPool2dUnpadded3 $ conv2dPreserving3z blackGlyph
   printAstPretty (simplifyInlineContract afcnn2T)
     @?= "rfromS (sconcrete (sfromListLinear [2,2,2,2] [7.0,0.0,7.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0]))"
   printAstPretty afcnn2T
@@ -1512,7 +1513,7 @@ testCNNOPP6 = do
 testCNNOPP6b :: Assertion
 testCNNOPP6b = do
   resetVarCounter
-  let artifactRev = revArtifactAdapt UseIncomingCotangent (maxPool2dUnpadded3 . conv2dSame3z) (FTKR [2, 2, 2, 2] (FTKScalar @Double))
+  let artifactRev = revArtifactAdapt UseIncomingCotangent (maxPool2dUnpadded3 . conv2dPreserving3z) (FTKR [2, 2, 2, 2] (FTKScalar @Double))
   printArtifactPrimalPretty (simplifyArtifactRev artifactRev)
     @?= "\\u1 -> rfromS (stranspose @[1, 2, 0] (sreplicate @2 (sfromVector @2 (fromList [sfromVector @2 (fromList [sfromVector0N @[2] (fromList [sfromR u1 `sindex0` [0, 0, 0, 0], 0.0]), sconcrete (sreplicate [2] 0.0)]), sconcrete (sreplicate [2,2] 0.0)]))))"
   printArtifactPrimalPretty artifactRev
@@ -1522,16 +1523,16 @@ testCNNOPP6b = do
   printArtifactPretty (simplifyArtifactRev artifactRev)
     @?= "\\dret u1 -> rfromS (soneHot (sfromK (ssum0 @[2] (stranspose @[0, 1, 3, 2] (sfromR dret) !$ [0, 0, 0]))) [0, 0, 0, 0])"
 
-conv2dSame3z
+conv2dPreserving3z
   :: (ADReady target, NumScalar r)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2dSame3z arrA =
+conv2dPreserving3z arrA =
   let shB = [2, 2, 2, 2]
   in rbuild shB $ \case
     [iImg, _, iBh, iBw] ->
       let arrAt = slicez3 shB arrA [iImg, iImg, iImg, iBw]
       in rindex @_ @0 arrAt [iBh, iBw, iImg, iBh]
-    _ -> error "conv2dSame3z: impossible pattern needlessly required"
+    _ -> error "conv2dPreserving3z: impossible pattern needlessly required"
 
 testCNNOPP7 :: Assertion
 testCNNOPP7 = do
@@ -1541,7 +1542,7 @@ testCNNOPP7 = do
                        (rconcrete $ Nested.rscalar 7
                         :: AstTensor AstMethodLet PrimalSpan (TKR 0 Double))
       afcnn2T :: AstTensor AstMethodLet FullSpan (TKR 4 Double)
-      afcnn2T = maxPool2dUnpadded3y $ conv2dSame3y blackGlyph
+      afcnn2T = maxPool2dUnpadded3y $ conv2dPreserving3y blackGlyph
   printAstPretty (simplifyInlineContract afcnn2T)
     @?= "rfromS (sconcrete (sfromListLinear [2,2,2,2] [7.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0]))"
   printAstPretty afcnn2T
@@ -1550,7 +1551,7 @@ testCNNOPP7 = do
 testCNNOPP7b :: Assertion
 testCNNOPP7b = do
   resetVarCounter
-  let artifactRev = revArtifactAdapt UseIncomingCotangent (maxPool2dUnpadded3y . conv2dSame3y) (FTKR [2, 2, 2, 2] (FTKScalar @Double))
+  let artifactRev = revArtifactAdapt UseIncomingCotangent (maxPool2dUnpadded3y . conv2dPreserving3y) (FTKR [2, 2, 2, 2] (FTKScalar @Double))
   printArtifactPrimalPretty (simplifyArtifactRev artifactRev)
     @?= "\\u1 -> rfromS (stranspose @[1, 2, 0] (sfromVector @2 (fromList [sfromVector @2 (fromList [sfromVector @2 (fromList [sfromVector0N @[2] (fromList [sfromR u1 `sindex0` [0, 0, 0, 0], 0.0]), sconcrete (sreplicate [2] 0.0)]), sconcrete (sreplicate [2,2] 0.0)]), sconcrete (sreplicate [2,2,2] 0.0)])))"
   printArtifactPrimalPretty artifactRev
@@ -1570,16 +1571,16 @@ maxPool2dUnpadded3y arr =
       in rmaximum3 arrt
     _ -> error "maxPool2dUnpadded3y: impossible pattern needlessly required"
 
-conv2dSame3y
+conv2dPreserving3y
   :: (ADReady target, NumScalar r)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2dSame3y arrA =
+conv2dPreserving3y arrA =
   let shB = [2, 2, 2, 2]
   in rbuild shB $ \case
     [iImg, _, iBh, iBw] ->
       let arrAt = slicez3 shB arrA [iImg, iImg, iImg, iBh]
       in rindex @_ @0 arrAt [iBh, iBw, iImg, iBh]
-    _ -> error "conv2dSame3y: impossible pattern needlessly required"
+    _ -> error "conv2dPreserving3y: impossible pattern needlessly required"
 
 testPaddedCNNOPP0c :: Assertion
 testPaddedCNNOPP0c = do
@@ -1772,8 +1773,8 @@ conv2dPadded2 arrK arrA =
 
 -- Hand-written reverse derivative of full convolution with respect
 -- to the kernels.
-testSameCNNOPPKrnHandwritten :: Assertion
-testSameCNNOPPKrnHandwritten = do
+testPreservingCNNOPPKrnHandwritten :: Assertion
+testPreservingCNNOPPKrnHandwritten = do
   resetVarCounter
   let ftk = FTKS (knownShS @'[3, 3, 6, 6]) (FTKScalar @Double)
       varNameA = mkAstVarName ftk . intToAstVarId $ 100000000
@@ -1781,21 +1782,21 @@ testSameCNNOPPKrnHandwritten = do
       varNameB = mkAstVarName ftk . intToAstVarId $ 100000099
       varB = AstVar varNameB
       t :: AstTensor AstMethodLet FullSpan (TKS [3, 3, 3, 3] Double)
-      t = conv2dSame_dKrn varA varB
+      t = conv2dPreserving_dKrn varA varB
   "\\u0 -> \\u99 -> " ++ printAstPretty t
     @?= "\\u0 -> \\u99 -> ssumN @[3, 1, 6, 6] (stranspose @[2, 3, 4, 5, 1, 0] (sreplicate @3 (stranspose @[1, 2, 3, 4, 5, 0] (sreplicate @3 (stranspose @[1, 2, 3, 4, 5, 0] (sreplicate @3 (stranspose @[1, 2, 0] (sreplicate @1 (str u99)))))))) * stranspose @[1, 2, 3, 4, 0] (sreplicate @3 (stranspose @[4, 0, 5, 6, 1, 2, 3] (sreplicate @1 (stranspose @[2, 3, 0, 4, 5, 1] (sgather @[3, 6] (stranspose @[4, 2, 0, 3, 1] (sgather @[3, 6] (stranspose @[2, 1, 0] u0) (\\[i18, i11] -> [i18 + i11]))) (\\[i16, i12] -> [i16 + i12])))))))"
   "\\u0 -> \\u99 -> " ++ printAstPretty (simplifyUserCode t)
     @?= "\\u0 -> \\u99 -> ssumN @[3, 1, 6, 6] (stranspose @[2, 3, 4, 5, 1, 0] (sreplicate @3 (stranspose @[1, 2, 3, 4, 5, 0] (sreplicate @3 (stranspose @[1, 2, 3, 4, 5, 0] (sreplicate @3 (stranspose @[1, 2, 0] (sreplicate @1 (str u99)))))))) * stranspose @[1, 2, 3, 4, 0] (sreplicate @3 (stranspose @[4, 0, 5, 6, 1, 2, 3] (sreplicate @1 (stranspose @[2, 3, 0, 4, 5, 1] (sgather @[3, 6] (stranspose @[4, 2, 0, 3, 1] (sgather @[3, 6] (stranspose @[2, 1, 0] u0) (\\[i35, i37] -> [i35 + i37]))) (\\[i16, i12] -> [i16 + i12])))))))"
 
 -- Convolution differentiated wrt the kernel.
-testSameCNNOPP0cW :: Assertion
-testSameCNNOPP0cW = do
+testPreservingCNNOPP0cW :: Assertion
+testPreservingCNNOPP0cW = do
   resetVarCounter
   let ftkD = FTKR (6 :$: 2 :$: 6 :$: 6 :$: ZSR) (FTKScalar @Double)
       varName = mkAstVarName ftkD . intToAstVarId $ 100000000
       var = AstVar varName
       ftkK = FTKR (2 :$: 2 :$: 2 :$: 2 :$: ZSR) (FTKScalar @Double)
-      f = flip conv2dSame var
+      f = flip conv2dPreserving var
       varName2 = mkAstVarName ftkD . intToAstVarId $ 100000000
       var2 = AstVar varName2
       env =
@@ -1813,14 +1814,14 @@ testSameCNNOPP0cW = do
     @?= "\\u0 -> \\dret u1 -> rfromS (ssumN @[6, 6] (sdot1In (stranspose @[5, 6, 0, 2, 3, 4, 1] (sreplicate @2 (stranspose @[2, 4, 5, 1, 3, 0] (sgather @[6, 2] (stranspose @[4, 2, 0, 3, 1] (sgather @[6, 2] (stranspose @[2, 0, 1] (sfromR u0)) (\\[i80, i82] -> [i80 + i82]))) (\\[i24, i25] -> [i24 + i25]))))) (stranspose @[5, 6, 4, 0, 1, 2, 3] (sreplicateN @[2, 2, 2] (sfromR dret)))))"
 
 -- Convolution differentiated wrt the data.
-testSameCNNOPP0bW :: Assertion
-testSameCNNOPP0bW = do
+testPreservingCNNOPP0bW :: Assertion
+testPreservingCNNOPP0bW = do
   resetVarCounter
   let ftkK = FTKR (2 :$: 2 :$: 2 :$: 2 :$: ZSR) (FTKScalar @Double)
       varName = mkAstVarName ftkK . intToAstVarId $ 100000000
       var = AstVar varName
       ftkD = FTKR (6 :$: 2 :$: 6 :$: 6 :$: ZSR) (FTKScalar @Double)
-      f = conv2dSame var
+      f = conv2dPreserving var
       varName2 = mkAstVarName ftkK . intToAstVarId $ 100000000
       var2 = AstVar varName2
       env =
@@ -1838,14 +1839,14 @@ testSameCNNOPP0bW = do
     @?= "\\u0 -> \\dret u1 -> rfromS (stranspose @[1, 2, 0] (sscatter @[6, 2] (stranspose @[2, 4, 1, 3, 0] (sscatter @[6, 2] (sdot1In (stranspose @[6, 3, 0, 5, 1, 2, 4] (sreplicate @6 (stranspose @[2, 3, 4, 1, 0] (sreplicate @6 (stranspose @[1, 2, 3, 4, 0] (sreplicate @6 (sfromR u0))))))) (stranspose @[6, 2, 3, 5, 0, 1, 4] (sreplicateN @[2, 2, 2] (sfromR dret)))) (\\[i28, i29] -> [i28 + i29]))) (\\[i30, i31] -> [i30 + i31])))"
 
 -- Convolution differentiated wrt both arguments.
-testSameCNNOPP1bW :: Assertion
-testSameCNNOPP1bW = do
+testPreservingCNNOPP1bW :: Assertion
+testPreservingCNNOPP1bW = do
   resetVarCounter
   let f :: AstTensor AstMethodLet FullSpan
                      (TKProduct (TKR 4 Double) (TKR 4 Double))
         -> AstTensor AstMethodLet FullSpan
                      (TKR 4 Double)
-      f v = conv2dSame (tproject1 v) (tproject2 v)
+      f v = conv2dPreserving (tproject1 v) (tproject2 v)
       ftk = FTKProduct (FTKR (2 :$: 2 :$: 2 :$: 2 :$: ZSR) FTKScalar)
                        (FTKR (6 :$: 2 :$: 6 :$: 6 :$: ZSR) FTKScalar)
       (artifactRev, _) =

--- a/test/simplified/TestGatherSimplified.hs
+++ b/test/simplified/TestGatherSimplified.hs
@@ -1329,19 +1329,19 @@ maxPool2dUnpadded2
 maxPool2dUnpadded2 a =
   rbuild [2, 2, 2, 2] $ \case
     [_, _, iBh, iBw] ->
-      let arrt = slicez2 (conv2dSame2 a) [iBw, 1, 2 * iBh, 2 * iBw]
+      let arrt = slicez2 (conv2dPreserving2 a) [iBw, 1, 2 * iBh, 2 * iBw]
       in rmaximum2 arrt
     _ -> error "maxPool2dUnpadded2: impossible pattern needlessly required"
 
-conv2dSame2
+conv2dPreserving2
   :: (target ~ AstTensor AstMethodLet FullSpan, r ~ Double)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2dSame2 a =
+conv2dPreserving2 a =
   rbuild [3, 3, 2, 2] $ \case
     [iImg, _, iBh, iBw] ->
       let arrAt = slicez2 a [iImg, 0, iBh, iBw]
       in rindex @_ @0 arrAt [0, iBw, iBw, 0]
-    _ -> error "conv2dSame2: impossible pattern needlessly required"
+    _ -> error "conv2dPreserving2: impossible pattern needlessly required"
 
 slicez2
   :: (target ~ AstTensor AstMethodLet FullSpan, r ~ Double, n ~ 4)
@@ -1367,7 +1367,7 @@ testCNNOPP3 = do
                        (rconcrete $ Nested.rscalar 7
                         :: AstTensor AstMethodLet PrimalSpan (TKR 0 Double))
       afcnn2T :: AstTensor AstMethodLet FullSpan (TKR 4 Double)
-      afcnn2T = maxPool2dUnpadded3 $ conv2dSame3 blackGlyph
+      afcnn2T = maxPool2dUnpadded3 $ conv2dPreserving3 blackGlyph
   printAstPretty (simplifyInlineContract afcnn2T)
     @?= "rfromS (sconcrete (sfromListLinear [2,2,2,2] [14.0,0.0,14.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0]))"
   printAstPretty afcnn2T
@@ -1376,7 +1376,7 @@ testCNNOPP3 = do
 testCNNOPP3b :: Assertion
 testCNNOPP3b = do
   resetVarCounter
-  let artifactRev = revArtifactAdapt UseIncomingCotangent (maxPool2dUnpadded3 . conv2dSame3) (FTKR [3, 3, 3, 3] (FTKScalar @Double))
+  let artifactRev = revArtifactAdapt UseIncomingCotangent (maxPool2dUnpadded3 . conv2dPreserving3) (FTKR [3, 3, 3, 3] (FTKScalar @Double))
   printArtifactPrimalPretty (simplifyArtifactRev artifactRev)
     @?= "\\u1 -> rfromS (stranspose @[1, 2, 0] (sreplicate @2 (sfromVector @2 (fromList [sfromVector @2 (fromList [sfromVector0N @[2] (fromList [sfromR u1 `sindex0` [0, 0, 0, 1] + sfromR u1 `sindex0` [0, 1, 1, 1], 0.0]), sconcrete (sreplicate [2] 0.0)]), sconcrete (sreplicate [2,2] 0.0)]))))"
   printArtifactPretty artifactRev
@@ -1397,16 +1397,16 @@ maxPool2dUnpadded3 arr =
       in rmaximum3 arrt
     _ -> error "maxPool2dUnpadded3: impossible pattern needlessly required"
 
-conv2dSame3
+conv2dPreserving3
   :: (ADReady target, NumScalar r)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2dSame3 arrA =
+conv2dPreserving3 arrA =
   let shB = [2, 2, 2, 2]
   in rbuild shB $ \case
     [iImg, _, iBh, iBw] ->
       let arrAt = slicez4 shB arrA [iImg, 0, iBw, 1]
       in rindex @_ @0 arrAt [0, iBw, iImg, iBh] + rindex arrAt [iImg, 1, iBw + 1, iBh]
-    _ -> error "conv2dSame3: impossible pattern needlessly required"
+    _ -> error "conv2dPreserving3: impossible pattern needlessly required"
 
 slicez3
   :: (ADReady target, NumScalar r, KnownNat n)
@@ -1474,7 +1474,7 @@ testCNNOPP5 = do
                        (rconcrete $ Nested.rscalar 7
                         :: AstTensor AstMethodLet PrimalSpan (TKR 0 Double))
       afcnn2T :: AstTensor AstMethodLet FullSpan (TKR 4 Double)
-      afcnn2T = conv2dSame4 blackGlyph
+      afcnn2T = conv2dPreserving4 blackGlyph
   printAstPretty (simplifyInlineContract afcnn2T)
     @?= "rfromPlain (rfromS (sreplicateN @[1, 1] (sgather @[2, 2] (sconcrete (sfromListLinear [2] [7.0,0.0])) (\\[i35, i32] -> [ifH (0 <=. sconcrete (sfromListLinear [2,2] [0,-1,-1,-2]) `sindex0` [i35, 0] &&* 0 <=. sconcrete (sfromListLinear [2,2] [0,-1,-1,-2]) `sindex0` [i32, 0]) 0 1]))))"
       -- TODO: was once "rfromS (sconcrete (sfromListLinear [1,1,2,2] [7.0,0.0,0.0,0.0]))"
@@ -1486,7 +1486,7 @@ testCNNOPP5 = do
 testCNNOPP5b :: Assertion
 testCNNOPP5b = do
   resetVarCounter
-  let artifactRev = revArtifactAdapt UseIncomingCotangent conv2dSame4 (FTKR [5, 5, 5, 5] (FTKScalar @Double))
+  let artifactRev = revArtifactAdapt UseIncomingCotangent conv2dPreserving4 (FTKR [5, 5, 5, 5] (FTKScalar @Double))
   printArtifactPrimalPretty (simplifyArtifactRev artifactRev)
     @?= "\\u1 -> rfromS (sreplicateN @[1, 1] (let m48 = sgather @[2, 2] (sconcrete (sfromListLinear [2] [0,1])) (\\[i46, i47] -> [ifH (0 <=. sconcrete (sfromListLinear [2,2] [0,-1,-1,-2]) `sindex0` [i46, 0] &&* 0 <=. sconcrete (sfromListLinear [2,2] [0,-1,-1,-2]) `sindex0` [i47, 0]) 0 1]) in sgather @[2, 2] (sfromVector @2 (fromList [str (sslice (SNat @0) (SNat @2) (str (sslice (SNat @0) (SNat @2) (sfromR u1 !$ [0, 0])))), sconcrete (sreplicate [2,2] 0.0)])) (\\[i49, i50] -> [m48 `sindex0` [i49, i50], i49, i50])))"
       -- TODO: was once "\\u1 -> rfromS (sreplicate @1 (sreplicate @1 (str (sfromVector (fromList [sfromVector (fromList [sfromR u1 `sindex0` [0, 0, 0, 0], 0.0]), sconcrete (sreplicate [2] 0.0)])))))"
@@ -1508,16 +1508,16 @@ maxPool2dUnpadded4 arr =
       in rmaximum3 arrt
     _ -> error "maxPool2dUnpadded4: impossible pattern needlessly required"
 
-conv2dSame4
+conv2dPreserving4
   :: (ADReady target, NumScalar r)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2dSame4 arrA =
+conv2dPreserving4 arrA =
   let shB = [1, 1, 2, 2]
   in rbuild shB $ \case
     [iImg, _, iBh, iBw] ->
       let arrAt = slicez4 shB arrA [iImg, 0, iBh, iBw]
       in rindex @_ @0 arrAt [0, 0, 0, 0]
-    _ -> error "conv2dSame4: impossible pattern needlessly required"
+    _ -> error "conv2dPreserving4: impossible pattern needlessly required"
 
 slicez4
   :: (ADReady target, NumScalar r, KnownNat n)
@@ -1533,7 +1533,7 @@ testCNNOPP6 = do
                        (rconcrete $ Nested.rscalar 7
                         :: AstTensor AstMethodLet PrimalSpan (TKR 0 Double))
       afcnn2T :: AstTensor AstMethodLet FullSpan (TKR 4 Double)
-      afcnn2T = maxPool2dUnpadded3 $ conv2dSame3z blackGlyph
+      afcnn2T = maxPool2dUnpadded3 $ conv2dPreserving3z blackGlyph
   printAstPretty (simplifyInlineContract afcnn2T)
     @?= "rfromS (sconcrete (sfromListLinear [2,2,2,2] [7.0,0.0,7.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0]))"
   printAstPretty afcnn2T
@@ -1542,7 +1542,7 @@ testCNNOPP6 = do
 testCNNOPP6b :: Assertion
 testCNNOPP6b = do
   resetVarCounter
-  let artifactRev = revArtifactAdapt UseIncomingCotangent (maxPool2dUnpadded3 . conv2dSame3z) (FTKR [2, 2, 2, 2] (FTKScalar @Double))
+  let artifactRev = revArtifactAdapt UseIncomingCotangent (maxPool2dUnpadded3 . conv2dPreserving3z) (FTKR [2, 2, 2, 2] (FTKScalar @Double))
   printArtifactPrimalPretty (simplifyArtifactRev artifactRev)
     @?= "\\u1 -> rfromS (stranspose @[1, 2, 0] (sreplicate @2 (sfromVector @2 (fromList [sfromVector @2 (fromList [sfromVector0N @[2] (fromList [sfromR u1 `sindex0` [0, 0, 0, 0], 0.0]), sconcrete (sreplicate [2] 0.0)]), sconcrete (sreplicate [2,2] 0.0)]))))"
   printArtifactPrimalPretty artifactRev
@@ -1552,16 +1552,16 @@ testCNNOPP6b = do
   printArtifactPretty (simplifyArtifactRev artifactRev)
     @?= "\\dret u1 -> rfromS (soneHot (sfromK (ssum0 @[2] (stranspose @[0, 1, 3, 2] (sfromR dret) !$ [0, 0, 0]))) [0, 0, 0, 0])"
 
-conv2dSame3z
+conv2dPreserving3z
   :: (ADReady target, NumScalar r)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2dSame3z arrA =
+conv2dPreserving3z arrA =
   let shB = [2, 2, 2, 2]
   in rbuild shB $ \case
     [iImg, _, iBh, iBw] ->
       let arrAt = slicez3 shB arrA [iImg, iImg, iImg, iBw]
       in rindex @_ @0 arrAt [iBh, iBw, iImg, iBh]
-    _ -> error "conv2dSame3z: impossible pattern needlessly required"
+    _ -> error "conv2dPreserving3z: impossible pattern needlessly required"
 
 testCNNOPP7 :: Assertion
 testCNNOPP7 = do
@@ -1571,7 +1571,7 @@ testCNNOPP7 = do
                        (rconcrete $ Nested.rscalar 7
                         :: AstTensor AstMethodLet PrimalSpan (TKR 0 Double))
       afcnn2T :: AstTensor AstMethodLet FullSpan (TKR 4 Double)
-      afcnn2T = maxPool2dUnpadded3y $ conv2dSame3y blackGlyph
+      afcnn2T = maxPool2dUnpadded3y $ conv2dPreserving3y blackGlyph
   printAstPretty (simplifyInlineContract afcnn2T)
     @?= "rfromS (sconcrete (sfromListLinear [2,2,2,2] [7.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0]))"
   printAstPretty afcnn2T
@@ -1580,7 +1580,7 @@ testCNNOPP7 = do
 testCNNOPP7b :: Assertion
 testCNNOPP7b = do
   resetVarCounter
-  let artifactRev = revArtifactAdapt UseIncomingCotangent (maxPool2dUnpadded3y . conv2dSame3y) (FTKR [2, 2, 2, 2] (FTKScalar @Double))
+  let artifactRev = revArtifactAdapt UseIncomingCotangent (maxPool2dUnpadded3y . conv2dPreserving3y) (FTKR [2, 2, 2, 2] (FTKScalar @Double))
   printArtifactPrimalPretty (simplifyArtifactRev artifactRev)
     @?= "\\u1 -> rfromS (stranspose @[1, 2, 0] (sfromVector @2 (fromList [sfromVector @2 (fromList [sfromVector @2 (fromList [sfromVector0N @[2] (fromList [sfromR u1 `sindex0` [0, 0, 0, 0], 0.0]), sconcrete (sreplicate [2] 0.0)]), sconcrete (sreplicate [2,2] 0.0)]), sconcrete (sreplicate [2,2,2] 0.0)])))"
   printArtifactPrimalPretty artifactRev
@@ -1600,16 +1600,16 @@ maxPool2dUnpadded3y arr =
       in rmaximum3 arrt
     _ -> error "maxPool2dUnpadded3y: impossible pattern needlessly required"
 
-conv2dSame3y
+conv2dPreserving3y
   :: (ADReady target, NumScalar r)
   => target (TKR 4 r) -> target (TKR 4 r)
-conv2dSame3y arrA =
+conv2dPreserving3y arrA =
   let shB = [2, 2, 2, 2]
   in rbuild shB $ \case
     [iImg, _, iBh, iBw] ->
       let arrAt = slicez3 shB arrA [iImg, iImg, iImg, iBh]
       in rindex @_ @0 arrAt [iBh, iBw, iImg, iBh]
-    _ -> error "conv2dSame3y: impossible pattern needlessly required"
+    _ -> error "conv2dPreserving3y: impossible pattern needlessly required"
 
 -- This test uses a disastrous version of smaximum, but shows how
 -- sargMax gets non-trivially vectorized, preserving sharing, too.

--- a/test/simplified/TestMnistPP.hs
+++ b/test/simplified/TestMnistPP.hs
@@ -3,11 +3,13 @@
 -- | Tests of MNIST nns that pretty-print resulting gradient and primal terms.
 module TestMnistPP
   ( testTrees
+  , cnnObjective
   ) where
 
 import Prelude
 
 import GHC.Exts (IsList (..))
+import GHC.TypeLits (KnownNat)
 import System.Random
 import Test.Tasty
 import Test.Tasty.HUnit hiding (assert)
@@ -681,6 +683,21 @@ testCNNOAst2 = do
                       (simplifyInlineContract @(TKR 2 Double) afcnn1))
     (afcnn2 valsInit)
 
+-- | The shaped two-layer CNN forward pass (@convMnistTwoS@, each layer with
+-- maxpool) with the input image embedded as a constant, as a function of the
+-- parameters. Shared by 'testCNNOPP2S' and the @cnn-*@ benchmarks in
+-- @bench/ConvVjpBench.hs@ (which pass a random glyph, since a constant
+-- broadcast folds the convolution gathers away).
+cnnObjective
+  :: forall target h w. (ADReady target, KnownNat h, KnownNat w)
+  => Concrete (TKS '[7, 1, h, w] Double)
+  -> MnistCnnShaped2.ADCnnMnistParametersShaped target h w 2 3 4 5 Double
+  -> target (TKS '[SizeMnistLabel, 7] Double)
+cnnObjective glyph =
+  MnistCnnShaped2.convMnistTwoS
+    (SNat @2) (SNat @3) (SNat @h) (SNat @w) (SNat @4) (SNat @5) (SNat @7)
+    (sconcrete $ unConcrete glyph)
+
 testCNNOPP2S :: Assertion
 testCNNOPP2S = do
   resetVarCounter
@@ -706,10 +723,7 @@ testCNNOPP2S = do
       afcnn2 :: ADReady f
              => MnistCnnShaped2.ADCnnMnistParametersShaped f 14 23 2 3 4 5 Double
              -> f (TKS '[SizeMnistLabel, 7] Double)
-      afcnn2 = MnistCnnShaped2.convMnistTwoS
-                 (SNat @2) (SNat @3) sizeMnistWidthI sizeMnistHeightI
-                 (SNat @4) (SNat @5) batch_size
-                 (sconcrete $ unConcrete blackGlyph)
+      afcnn2 = cnnObjective blackGlyph
       artifactRev = revArtifactAdapt UseIncomingCotangent afcnn2 ftk
   printArtifactPrimalPretty (simplifyArtifactRev artifactRev)
     @?= "\\u1 -> let t236 = ssum @4 (sdot1In (sfromPlain (stranspose @[2, 0, 3, 4, 1] (sreplicate @4 (stranspose @[3, 1, 2, 0] (sgather @[23, 4] (stranspose @[2, 0, 1] (sgather @[14, 3] (sreplicate0N @[14, 23] 7.0) (\\[i434, i435] -> [i434 + i435]))) (\\[i230, i231] -> [i230 + i231])))))) (stranspose @[3, 1, 0, 4, 2] (sreplicate @14 (stranspose @[1, 2, 3, 0] (sreplicate @23 (str (tproject1 (tproject1 (tproject1 u1))) !$ [0])))))) + stranspose @[2, 0, 1] (sreplicateN @[14, 23] (tproject2 (tproject1 (tproject1 u1)))) ; u250 = sreshape @[4, 7, 11, 4] (stranspose @[2, 3, 4, 0, 1] (sreplicateN @[1, 1] (sfromPlain (sgather @[4, 7, 11, 2, 2] (sconcrete (sfromListLinear [2] [0.0,1.0])) (\\[i239, i240, i241, i242, i243] -> [ifH (0.0 <=. negate (splainPart t236 `sindex0` [i239, sconcrete (sfromListLinear [7,2] [0,1,2,3,4,5,6,7,8,9,10,11,12,13]) `sindex0` [i240, i242], sconcrete (sfromListLinear [11,2] [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21]) `sindex0` [i241, i243]])) 0 1])) * stranspose @[4, 0, 1, 2, 3] (sgather @[7, 11, 2, 2] (stranspose @[1, 2, 0] t236) (\\[i244, i245, i246, i247] -> [sconcrete (sfromListLinear [7,2] [0,1,2,3,4,5,6,7,8,9,10,11,12,13]) `sindex0` [i244, i246], sconcrete (sfromListLinear [11,2] [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21]) `sindex0` [i245, i247]]))))) ; t259 = ssumN @[3, 4] (sdot1In (stranspose @[2, 3, 0, 4, 5, 1] (sreplicate @4 (stranspose @[4, 2, 3, 0, 1] (sgather @[7, 11, 3, 4] (stranspose @[3, 4, 5, 6, 0, 1, 2] (sgather @[7, 11, 4] (stranspose @[4, 3, 2, 1, 7, 6, 5, 0] (sreplicate @4 (stranspose @[3, 4, 5, 6, 0, 1, 2] (sreplicateN @[3, 11, 7] (stranspose @[3, 2, 1, 0] u250))))) (\\[i427, i428, i429] -> [i429, i427, i428, kargMax (splainPart u250 !$ [i429, i427, i428])]))) (\\[i254, i255, i256, i257] -> [i254, i255, i256, i257, i254 + i256, i255 + i257]))))) (stranspose @[3, 4, 1, 0, 5, 2] (sreplicate @7 (stranspose @[1, 2, 3, 4, 0] (sreplicate @11 (tproject1 (tproject2 (tproject1 u1)))))))) + stranspose @[2, 0, 1] (sreplicateN @[7, 11] (tproject2 (tproject2 (tproject1 u1)))) ; u273 = sreshape @[4, 3, 5, 4] (stranspose @[2, 3, 4, 0, 1] (sreplicateN @[1, 1] (sfromPlain (sgather @[4, 3, 5, 2, 2] (sconcrete (sfromListLinear [2] [0.0,1.0])) (\\[i262, i263, i264, i265, i266] -> [ifH (0.0 <=. negate (splainPart t259 `sindex0` [i262, sconcrete (sfromListLinear [3,2] [0,1,2,3,4,5]) `sindex0` [i263, i265], sconcrete (sfromListLinear [5,2] [0,1,2,3,4,5,6,7,8,9]) `sindex0` [i264, i266]])) 0 1])) * stranspose @[4, 0, 1, 2, 3] (sgather @[3, 5, 2, 2] (stranspose @[1, 2, 0] t259) (\\[i267, i268, i269, i270] -> [sconcrete (sfromListLinear [3,2] [0,1,2,3,4,5]) `sindex0` [i267, i269], sconcrete (sfromListLinear [5,2] [0,1,2,3,4,5,6,7,8,9]) `sindex0` [i268, i270]]))))) ; m278 = str (sreplicate @7 (sdot1In (tproject1 (tproject1 (tproject2 u1))) (sreplicate @5 (sreshape @[60] (sgather @[4, 3, 5] u273 (\\[i274, i275, i276] -> [i274, i275, i276, kargMax (splainPart u273 !$ [i274, i275, i276])])))))) + str (sreplicate @7 (tproject2 (tproject1 (tproject2 u1)))) in smatmul2 (tproject1 (tproject2 (tproject2 u1))) (sfromPlain (sgather @[5, 7] (sconcrete (sfromListLinear [2] [0.0,1.0])) (\\[i279, i280] -> [ifH (0.0 <=. negate (splainPart m278 `sindex0` [i279, i280])) 0 1])) * m278) + str (sreplicate @7 (tproject2 (tproject2 (tproject2 u1))))"

--- a/tools/check-conv-bench-props.py
+++ b/tools/check-conv-bench-props.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Verify the numbered time properties of bench/ConvVjpBench.hs.
+
+Usage: python3 tools/check-conv-bench-props.py CSV
+
+CSV is criterion's --csv output from a full run of the suite (no
+benchmark filter):
+
+    cabal bench convVjpBench --enable-optimization \\
+      --benchmark-options='--csv FILE'
+
+The properties are stated and explained in the module haddock of
+bench/ConvVjpBench.hs — that list is canonical and this script is its
+executable form; keep the two in sync. Each property relates criterion
+means and is checked up to 10% tolerance: `a == b` stands for
+`abs (a - b) <= max a b / 10`, and `a <= b` for `a <= 1.1 * b`.
+
+The haddock also explains the categories echoed in the output:
+properties 1-3 are accounting, so a failure there means the measurement
+itself broke; property 4 records simplifier behavior; properties 5-6
+are engine invariants, so a failure is an engine regression; properties
+7-15 record the cost model of the current interpreted gather/scatter
+kernels and are the ones to re-measure when those kernels change.
+
+A benchmark missing from the CSV aborts with its name, and a benchmark
+that no property touches is reported as a failure — so a newly added
+benchmark forces the property list to be re-normalized.
+
+Exit status is nonzero if any check fails. Non-vacuity was demonstrated
+on 2026-07-21: inflating 48x48/S-exec by 30% in a CSV copy failed
+exactly properties 1 and 6, and an extra CSV row failed the coverage
+guard, each with exit status 1.
+"""
+import csv
+import sys
+
+if len(sys.argv) != 2:
+    sys.exit(__doc__.split("\n\n")[1])
+
+
+class TrackedTimes(dict):
+    """Records which benchmarks the properties touch, for the coverage
+    guard, and turns a missing benchmark into a readable abort."""
+
+    def __init__(self):
+        super().__init__()
+        self.used = set()
+
+    def __getitem__(self, k):
+        if k not in self:
+            sys.exit(f"benchmark missing from the CSV (not a full run?): {k}")
+        self.used.add(k)
+        return super().__getitem__(k)
+
+
+t = TrackedTimes()
+with open(sys.argv[1]) as f:
+    for row in csv.DictReader(f):
+        t[row["Name"]] = float(row["Mean"])
+
+
+def fmt(s):
+    if s >= 1:
+        return f"{s:.3f}s"
+    if s >= 1e-3:
+        return f"{s*1e3:.3f}ms"
+    return f"{s*1e6:.1f}us"
+
+
+fails = 0
+
+
+def eq(prop, an, bn, a, b):
+    global fails
+    ok = abs(a - b) <= max(a, b) / 10
+    d = abs(a - b) / max(a, b) * 100
+    print(f"  [{prop}] {an} {fmt(a)} == {bn} {fmt(b)}  (diff {d:.1f}%)"
+          f"  {'PASS' if ok else 'FAIL'}")
+    if not ok:
+        fails += 1
+
+
+def le(prop, an, bn, a, b):
+    global fails
+    ok = a <= 1.1 * b
+    print(f"  [{prop}] {an} {fmt(a)} <= {bn} {fmt(b)}  (ratio {a/b:.2f})"
+          f"  {'PASS' if ok else 'FAIL'}")
+    if not ok:
+        fails += 1
+
+
+SIZES = ["6x6", "24x24", "48x48", "96x96", "192x192"]
+SWEEPS = SIZES + ["inp-" + s for s in SIZES]
+CNNS = ["cnn-6x6", "cnn-12x12", "cnn-24x24"]
+
+print("-- accounting (any engine; violation = broken measurement) --")
+print("1. S-fullpipe-honest == S-artifact + S-exec")
+for g in SWEEPS + CNNS:
+    eq(1, f"{g}/S-fullpipe-honest", f"{g}/S-artifact + {g}/S-exec",
+       t[f"{g}/S-fullpipe-honest"], t[f"{g}/S-artifact"] + t[f"{g}/S-exec"])
+
+print("2. H-exec-raw <= H-fullpipe <= H-term + H-exec-raw")
+for g in SWEEPS:
+    le(2, f"{g}/H-exec-raw", f"{g}/H-fullpipe",
+       t[f"{g}/H-exec-raw"], t[f"{g}/H-fullpipe"])
+    le(2, f"{g}/H-fullpipe", f"{g}/H-term + {g}/H-exec-raw",
+       t[f"{g}/H-fullpipe"], t[f"{g}/H-term"] + t[f"{g}/H-exec-raw"])
+
+print("3. 6x6/S-exec <= S-fullpipe-hoisted-6x6 <= 6x6/S-fullpipe-honest")
+le(3, "6x6/S-exec", "hoisted",
+   t["6x6/S-exec"], t["pitfalls/S-fullpipe-hoisted-6x6"])
+le(3, "hoisted", "6x6/S-fullpipe-honest",
+   t["pitfalls/S-fullpipe-hoisted-6x6"], t["6x6/S-fullpipe-honest"])
+
+print("-- simplifier recorder --")
+print("4. pitfalls/H-exec-const-48x48 == 48x48/H-exec")
+eq(4, "H-exec-const-48x48", "48x48/H-exec",
+   t["pitfalls/H-exec-const-48x48"], t["48x48/H-exec"])
+
+print("-- engine invariants (violation = regression) --")
+print("5. S-exec <= S-exec-raw; H-exec <= H-exec-raw")
+for g in SWEEPS + CNNS:
+    le(5, f"{g}/S-exec", f"{g}/S-exec-raw",
+       t[f"{g}/S-exec"], t[f"{g}/S-exec-raw"])
+for g in SWEEPS:
+    le(5, f"{g}/H-exec", f"{g}/H-exec-raw",
+       t[f"{g}/H-exec"], t[f"{g}/H-exec-raw"])
+
+print("6. S-exec <= H-exec")
+for g in SWEEPS:
+    le(6, f"{g}/S-exec", f"{g}/H-exec", t[f"{g}/S-exec"], t[f"{g}/H-exec"])
+
+print("-- cost model of the current kernels (re-measure on kernel change) --")
+G = "gather48/"
+print("7. two-gathers-ad-shm-sorted == two-gathers-ad-orient")
+eq(7, "shm-sorted", "ad-orient",
+   t[G + "two-gathers-ad-shm-sorted"], t[G + "two-gathers-ad-orient"])
+print("8. two-gathers-ad-shn-sorted <= two-gathers-ad-orient")
+le(8, "shn-sorted", "ad-orient",
+   t[G + "two-gathers-ad-shn-sorted"], t[G + "two-gathers-ad-orient"])
+print("9. two-gathers-vec-orient <= two-gathers-ad-orient")
+le(9, "vec-orient", "ad-orient",
+   t[G + "two-gathers-vec-orient"], t[G + "two-gathers-ad-orient"])
+print("10. the four fused-gather-* pairwise equal")
+fused = ["fused-gather-ad-orient", "fused-gather-vec-orient",
+         "fused-gather-shm-sorted-asc", "fused-gather-shm-sorted-desc"]
+for i in range(len(fused)):
+    for j in range(i + 1, len(fused)):
+        eq(10, fused[i], fused[j], t[G + fused[i]], t[G + fused[j]])
+print("11. two-gathers-ad-orient <= fused-gather-ad-orient")
+le(11, "two-gathers-ad", "fused-gather-ad",
+   t[G + "two-gathers-ad-orient"], t[G + "fused-gather-ad-orient"])
+
+S = "scatter48/"
+print("12. two-scatters-ad-orient == two-scatters-vec-orient")
+eq(12, "ad-orient", "vec-orient",
+   t[S + "two-scatters-ad-orient"], t[S + "two-scatters-vec-orient"])
+print("13. two-scatters-ad-orient <= two-scatters-ad-shn-sorted")
+le(13, "ad-orient", "shn-sorted",
+   t[S + "two-scatters-ad-orient"], t[S + "two-scatters-ad-shn-sorted"])
+print("14. two-scatters-X <= fused-scatter-X, X in {ad, vec}")
+le(14, "two-scatters-ad", "fused-scatter-ad",
+   t[S + "two-scatters-ad-orient"], t[S + "fused-scatter-ad-orient"])
+le(14, "two-scatters-vec", "fused-scatter-vec",
+   t[S + "two-scatters-vec-orient"], t[S + "fused-scatter-vec-orient"])
+print("15. two-scatters-ad-orient <= two-gathers-ad-orient")
+le(15, "two-scatters-ad", "two-gathers-ad",
+   t[S + "two-scatters-ad-orient"], t[G + "two-gathers-ad-orient"])
+
+untouched = sorted(set(t) - t.used)
+if untouched:
+    print("\ncoverage: benchmarks untouched by any property — extend the")
+    print("numbered list in bench/ConvVjpBench.hs's module haddock:")
+    for n in untouched:
+        print(f"  {n}")
+    fails += len(untouched)
+
+print(f"\n{fails} check(s) FAILED" if fails else "\nall checks PASS")
+sys.exit(1 if fails else 0)

--- a/tools/check-plan-citations.py
+++ b/tools/check-plan-citations.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Check that file:line citations in a planning document still resolve.
+
+Usage: python3 tools/check-plan-citations.py [DOC]
+DOC defaults to CLAUDE.md. Run from the repo root.
+
+For every citation of the form `path/to/File.hs:12` or `File.hs:12-34`
+(also .ts, .cabal, .mjs, .html and the Makefile), the script resolves the
+file, checks the line range exists, and prints the first cited line so a
+human can compare it against what the surrounding sentence claims. A
+`/.../` component in a cited path is treated as a wildcard (the document
+uses it to abbreviate long paths).
+
+Exit status is nonzero if any citation is UNRESOLVED (no such file),
+AMBIGUOUS (a bare basename matching several files — qualify it in the
+document), or OUT-OF-RANGE (the file is shorter than the cited line).
+
+Line numbers drift as commits land: after changing a cited file, re-run
+this and eyeball the printed snippets; the document header records the
+commit its citations were last verified against.
+
+Pinned GitHub permalinks (`https://github.com/.../blob/<commit>/<path>#L12`
+or `#L12-L34`) are also checked, against the pinned commit via
+`git show <commit>:<path>` — they never drift, so this catches typos,
+wrong ranges and links whose commit or path is not in this repository
+(foreign-repo links cannot be verified locally and are reported as
+failures).
+
+Scope limits, deliberate: prose-style citations ("config.ui.default line
+67") are not extracted, and the *claims* around citations are not checked
+— in particular, universally-quantified claims ("only X does Y", "exactly
+two", "never") must be re-verified by repo-wide grep, not by re-reading
+the cited file; that asymmetry is how a real error slipped in once.
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+SEARCH_ROOTS = ["src", "test", "bench", "example", "tools", "."]
+CITE_RE = re.compile(
+    r"`?([A-Za-z][A-Za-z0-9_./-]*\.(?:hs|ts|cabal|mjs|html)|Makefile)"
+    r":(\d+)(?:-(\d+))?")
+URL_RE = re.compile(
+    r"https://github\.com/[\w.-]+/[\w.-]+/blob/([0-9a-f]{7,40})/"
+    r"([A-Za-z0-9_./-]+)#L(\d+)(?:-L(\d+))?")
+
+
+def all_files_named(basename):
+    out = subprocess.run(
+        ["bash", "-c",
+         "find " + " ".join(SEARCH_ROOTS[:-1])
+         + f" -name {basename} 2>/dev/null; ls {basename} 2>/dev/null"],
+        capture_output=True, text=True).stdout.split()
+    return sorted(set(out))
+
+
+def resolve(name):
+    """Return (path, error) — exactly one of the two is None."""
+    if "/.../" in name:
+        prefix, suffix = name.split("/.../", 1)
+        hits = [h for h in all_files_named(os.path.basename(name))
+                if h.startswith(prefix) and h.endswith("/" + suffix)]
+        if len(hits) == 1:
+            return hits[0], None
+        return None, f"wildcard resolves to {hits or 'nothing'}"
+    if os.path.exists(name):
+        return name, None
+    hits = [h for h in all_files_named(os.path.basename(name))
+            if h.endswith("/" + name)]
+    if len(hits) == 1:
+        return hits[0], None
+    if not hits:
+        return None, "UNRESOLVED"
+    return None, f"AMBIGUOUS: {hits} — qualify the citation"
+
+
+def main():
+    doc = sys.argv[1] if len(sys.argv) > 1 else "CLAUDE.md"
+    text = open(doc, encoding="utf-8").read()
+    cites = sorted({(m.group(1), int(m.group(2)),
+                     int(m.group(3) or m.group(2)))
+                    for m in CITE_RE.finditer(text)})
+    failures = 0
+    for name, lo, hi in cites:
+        path, err = resolve(name)
+        if err:
+            print(f"FAIL {name}:{lo}-{hi} — {err}")
+            failures += 1
+            continue
+        lines = open(path, encoding="utf-8",
+                     errors="replace").read().splitlines()
+        if hi > len(lines):
+            print(f"FAIL {name}:{lo}-{hi} — OUT-OF-RANGE "
+                  f"(file has {len(lines)} lines)")
+            failures += 1
+            continue
+        span = f"{lo}" if lo == hi else f"{lo}-{hi}"
+        print(f"ok   {name}:{span} | {lines[lo - 1].strip()[:80]}")
+    urlcites = sorted({(m.group(1), m.group(2), int(m.group(3)),
+                        int(m.group(4) or m.group(3)))
+                       for m in URL_RE.finditer(text)})
+    for sha, path, lo, hi in urlcites:
+        proc = subprocess.run(["git", "show", f"{sha}:{path}"],
+                              capture_output=True, text=True)
+        if proc.returncode != 0:
+            print(f"FAIL {path}#L{lo}-L{hi} @ {sha[:9]} — commit or path"
+                  f" not in this repository")
+            failures += 1
+            continue
+        lines = proc.stdout.splitlines()
+        if hi > len(lines):
+            print(f"FAIL {path}#L{lo}-L{hi} @ {sha[:9]} — OUT-OF-RANGE "
+                  f"(file has {len(lines)} lines at that commit)")
+            failures += 1
+            continue
+        span = f"L{lo}" if lo == hi else f"L{lo}-L{hi}"
+        print(f"ok   {path}#{span} @ {sha[:9]}"
+              f" | {lines[lo - 1].strip()[:70]}")
+    print(f"\n{len(cites) + len(urlcites)} citations checked,"
+          f" {failures} failed"
+          f" — now eyeball the snippets against the document's claims.")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
  This is the benchmark, test, documentation and tooling half of the #123
  work, split out so it can land before the engine change: it contains no
  changes under `src/HordeAd/Core` beyond a comment-link pin — the gather
  shn-sort contraction fix and its printed-AST refresh follow in a
  companion PR. Follow-up to #128 and #129.

  **Benchmarks.** `bench/ConvVjpBench.hs` is reworked into an honest,
  pairwise-comparable suite: the two #123 pipelines (S = Symbolic, H =
  handwritten-vectorized) are decomposed into adjacent stage pairs —
  `S-fullpipe-honest`/`H-fullpipe`, `S-artifact`/`H-term`,
  `S-exec`/`H-exec`, `S-exec-raw`/`H-exec-raw` — with the incoming
  cotangent kept as a variable on both sides; known measurement traps
  (artifact hoisting, constant-cotangent embedding) are quarantined as
  single recorders in a `pitfalls` group, so the sweep groups hold only
  honest variants. New `cnn-*` groups time a real shaped two-layer CNN
  gradient at 6x6, 12x12 and 24x24, sharing the objective with the
  printed-AST test via `cnnObjective`, newly exported from TestMnistPP —
  share code, not configuration. The `gather48`/`scatter48`
  micro-benchmarks are completed (fused-then-sorted gather variants, the
  shn-sorted scatter adjoint), benchmark names adopt the ad/vec
  vocabulary for the two gather orientations, and every gather/scatter
  chain pair is verified at startup via the adjoint law: for all `f`,
  `x` and `y`, `sdot0 (sgather x f) y == sdot0 x (sscatter y f)`.

  **Time properties.** The module haddock states fifteen numbered
  (in)equalities between the criterion means of a full run, each checked
  up to 10% tolerance and classified: accounting identities (a violation
  means the measurement broke), a simplifier recorder, engine invariants
  (a violation is a regression) and cost-model rulings (to re-measure
  when the kernels change). `tools/check-conv-bench-props.py` is the
  list in executable form and guards its own coverage — a benchmark no
  property touches is a failure. All 89 checks pass on a full criterion
  run with the companion fix applied; on this branch alone, property 6
  (`time(S-exec) <= time(H-exec)`) documents the target state — its
  failure against the current engine is exactly the #123 gap the
  companion PR closes.

  **Tests.** TestConvCorrect now value-checks the interpreted
  handwritten gradient path — the one every `H-` variant and every
  HandwrittenVectorized poor man's benchmark times, which no test had
  pinned: six vectorized legs plus a var-cotangent case (raw and
  contracted, dKrn and dInp). Non-vacuity was proven by deliberately
  breaking each new assertion and confirming exactly the expected
  failures. TestConvQuickCheck's haddocks defer stage-for-stage
  comparison to the criterion suite and explain why
  HandwrittenVectorized cannot be amortized.

  **Rename.** `conv2dSame`/`conv2dSameS` and family become
  `conv2dPreserving*`: "same" collided with the English word in every
  comment around it, so the family is named for the property itself —
  the output image size is preserved. Ancient code included; plain-prose
  "same" untouched.

  **CI.** The benchmarks step smoke-runs the entire suite with
  `--benchmark-options='-n 1'` — every benchmark once, no statistics,
  seconds total — on all three GHC versions: build-and-runtime
  protection, not a perf tripwire.

  **Tooling and docs.** `tools/check-plan-citations.py` re-validates
  file:line citations and pinned permalinks in reference documents (the
  one unpinned source permalink, AstInline.hs's CHAD reference, is
  pinned accordingly); `.hlint.yaml` keeps `-XNoStarIsType` (mirroring
  the cabal's `default-extensions`) and drops `--cpp-simple` for the
  fixed hlint v3.10; the README's Coding style section spells out the
  comment-prefix and alignment rules; and CLAUDE.md (guidance for Claude
  Code sessions) is added. CLAUDE.md's performance model documents the
  whole #123 investigation, so parts of it describe the companion branch
  (the contraction rule, `notes-add-zero-gather.md`); they are kept
  verbatim deliberately.

  **Validation.** Build, minimalTest and the full CAFlessTest suite are
  green on this branch — the printed-AST expectations match the
  unchanged engine — and every commit compiles in isolation;
  stylish-haskell is clean on all touched files; hlint reports zero
  errors repo-wide.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)